### PR TITLE
measure: Handle nil values that crash OpenStudio.convert

### DIFF
--- a/lib/measures/default_feature_reports/measure.rb
+++ b/lib/measures/default_feature_reports/measure.rb
@@ -234,6 +234,9 @@ class DefaultFeatureReports < OpenStudio::Measure::ReportingMeasure
   # unit conversion method
   def convert_units(value, from_units, to_units)
     # apply unit conversion
+    if value.nil?
+      return nil
+    end
     value_converted = OpenStudio.convert(value, from_units, to_units)
     if value_converted.is_initialized
       value = value_converted.get


### PR DESCRIPTION
### Resolves #17 

### Pull Request Description

Check for nil values during unit conversion before calling `Openstudio.convert`

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] Documentation has been modified appropriately
- [ ] All ci tests pass (green)
- [x] An [ISSUE](https://github.com/urbanopt/urbanopt-reporting-gem/issues) has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run.
- [x] This branch is up-to-date with develop
