### PR TITLE
Support reporting of other fuels

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-URBANopt<sup>&trade;</sup>, Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC, and other 
+URBANopt (tm), Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC, and other 
 contributors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, 

--- a/doc_templates/LICENSE.md
+++ b/doc_templates/LICENSE.md
@@ -1,4 +1,4 @@
-URBANopt™, Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC, and other 
+URBANopt (tm), Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC, and other 
 contributors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, 

--- a/doc_templates/copyright_erb.txt
+++ b/doc_templates/copyright_erb.txt
@@ -1,6 +1,6 @@
 <%
   # *********************************************************************************
-  # URBANopt™, Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC, and other
+  # URBANopt (tm), Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC, and other
   # contributors. All rights reserved.
   #
   # Redistribution and use in source and binary forms, with or without modification,

--- a/doc_templates/copyright_js.txt
+++ b/doc_templates/copyright_js.txt
@@ -1,4 +1,4 @@
 /* @preserve
- * URBANopt™, Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC, and other contributors. All rights reserved.
+ * URBANopt (tm), Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC, and other contributors. All rights reserved.
  * Use of this source code is governed by the BSD 3-Clause license.
 */

--- a/doc_templates/copyright_ruby.txt
+++ b/doc_templates/copyright_ruby.txt
@@ -1,5 +1,5 @@
 # *********************************************************************************
-# URBANopt™, Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC, and other
+# URBANopt (tm), Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC, and other
 # contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,

--- a/lib/measures/default_feature_reports/LICENSE.md
+++ b/lib/measures/default_feature_reports/LICENSE.md
@@ -1,4 +1,4 @@
-URBANopt™, Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC, and other 
+URBANopt (tm), Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC, and other 
 contributors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, 

--- a/lib/measures/default_feature_reports/measure.rb
+++ b/lib/measures/default_feature_reports/measure.rb
@@ -1,5 +1,5 @@
 # *********************************************************************************
-# URBANopt™, Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC, and other
+# URBANopt (tm), Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC, and other
 # contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,

--- a/lib/measures/default_feature_reports/measure.rb
+++ b/lib/measures/default_feature_reports/measure.rb
@@ -102,6 +102,8 @@ class DefaultFeatureReports < OpenStudio::Measure::ReportingMeasure
     fuel_types = {
       'Electricity' => 'Electricity',
       'Gas' => 'Natural Gas',
+      'FuelOil#2' => 'Fuel Oil #2',
+      'Propane' => 'Propane',
       'AdditionalFuel' => 'Additional Fuel',
       'DistrictCooling' => 'District Cooling',
       'DistrictHeating' => 'District Heating',
@@ -617,6 +619,8 @@ class DefaultFeatureReports < OpenStudio::Measure::ReportingMeasure
 
     # get fuel type as listed in the sql file
     fueltypes = fuel_types.values
+    fueltypes.delete('Propane')
+    fueltypes.delete('Fuel Oil #2')
 
     # get enduses as listed in the sql file
     enduses = end_uses.values
@@ -728,6 +732,8 @@ class DefaultFeatureReports < OpenStudio::Measure::ReportingMeasure
       'Electricity:Facility',
       'ElectricityProduced:Facility',
       'Gas:Facility',
+      'Propane:Facility',
+      'FuelOil#2:Facility',
       'Cooling:Electricity',
       'Heating:Electricity',
       'InteriorLights:Electricity',
@@ -741,6 +747,14 @@ class DefaultFeatureReports < OpenStudio::Measure::ReportingMeasure
       'Heating:Gas',
       'WaterSystems:Gas',
       'InteriorEquipment:Gas',
+      'HeatRejection:Propane',
+      'Heating:Propane',
+      'WaterSystems:Propane',
+      'InteriorEquipment:Propane',
+      'HeatRejection:FuelOil#2',
+      'Heating:FuelOil#2',
+      'WaterSystems:FuelOil#2',
+      'InteriorEquipment:FuelOil#2',
       'DistrictCooling:Facility',
       'DistrictHeating:Facility',
       'District Cooling Chilled Water Rate',
@@ -867,7 +881,7 @@ class DefaultFeatureReports < OpenStudio::Measure::ReportingMeasure
         # unit conversion
         old_unit = ts.get.units if ts.is_initialized
 
-        if timeseries_name.include? 'Gas'
+        if timeseries_name.include?('Gas') || timeseries_name.include?('Propane') || timeseries_name.include?('FuelOil#2')
           new_unit = 'kBtu'
         else
           new_unit = case old_unit.to_s

--- a/lib/measures/default_feature_reports/measure.rb
+++ b/lib/measures/default_feature_reports/measure.rb
@@ -99,37 +99,39 @@ class DefaultFeatureReports < OpenStudio::Measure::ReportingMeasure
 
   # define fuel types
   def fuel_types
-    fuel_types = [
-      'Electricity',
-      'Gas',
-      'AdditionalFuel',
-      'DistrictCooling',
-      'DistrictHeating',
-      'Water'
-    ]
+    fuel_types = {
+      'Electricity' => 'Electricity',
+      'Gas' => 'Natural Gas',
+      'Propane' => 'Propane',
+      # 'FuelOil2' => 'Fuel Oil 2',
+      'AdditionalFuel' => 'Additional Fuel',
+      'DistrictCooling' => 'District Cooling',
+      'DistrictHeating' => 'District Heating',
+      'Water' => 'Water'
+    }
 
     return fuel_types
   end
 
   # define enduses
   def end_uses
-    end_uses = [
-      'Heating',
-      'Cooling',
-      'InteriorLights',
-      'ExteriorLights',
-      'InteriorEquipment',
-      'ExteriorEquipment',
-      'Fans',
-      'Pumps',
-      'HeatRejection',
-      'Humidifier',
-      'HeatRecovery',
-      'WaterSystems',
-      'Refrigeration',
-      'Generators',
-      'Facility'
-    ]
+    end_uses = {
+      'Heating' => 'Heating',
+      'Cooling' => 'Cooling',
+      'InteriorLights' => 'Interior Lighting',
+      'ExteriorLights' => 'Exterior Lighting',
+      'InteriorEquipment' => 'Interior Equipment',
+      'ExteriorEquipment' => 'Exterior Equipment',
+      'Fans' => 'Fans',
+      'Pumps' => 'Pumps',
+      'HeatRejection' => 'Heat Rejection',
+      'Humidifier' => 'Humidification',
+      'HeatRecovery' => 'Heat Recovery',
+      'WaterSystems' => 'Water Systems',
+      'Refrigeration' => 'Refrigeration',
+      'Generators' => 'Generators',
+      'Facility' => 'Facility'
+    }
 
     return end_uses
   end
@@ -163,7 +165,9 @@ class DefaultFeatureReports < OpenStudio::Measure::ReportingMeasure
 
     # Request the output for each end use/fuel type combination
     end_uses.each do |end_use|
+      end_use, _ = end_use
       fuel_types.each do |fuel_type|
+        fuel_type, _ = fuel_type
         variable_name = if end_use == 'Facility'
                           "#{fuel_type}:#{end_use}"
                         else
@@ -572,6 +576,10 @@ class DefaultFeatureReports < OpenStudio::Measure::ReportingMeasure
     natural_gas = sql_query(runner, sql_file, 'AnnualBuildingUtilityPerformanceSummary', "TableName='End Uses' AND RowName='Total End Uses' AND ColumnName='Natural Gas'")
     feature_report.reporting_periods[0].natural_gas_kwh = convert_units(natural_gas, 'GJ', 'kWh')
 
+    # propane
+    propane = sql_query(runner, sql_file, 'EnergyMeters', "TableName='Annual and Peak Values - Other' AND RowName='Propane:Facility' AND ColumnName='Annual Value'")
+    feature_report.reporting_periods[0].propane_kwh = convert_units(propane, 'GJ', 'kWh')
+
     # additional_fuel
     additional_fuel = sql_query(runner, sql_file, 'AnnualBuildingUtilityPerformanceSummary', "TableName='End Uses' AND RowName='Total End Uses' AND ColumnName='Additional Fuel'")
     feature_report.reporting_periods[0].additional_fuel_kwh = convert_units(additional_fuel, 'GJ', 'kWh')
@@ -596,11 +604,11 @@ class DefaultFeatureReports < OpenStudio::Measure::ReportingMeasure
     ## end_uses
 
     # get fuel type as listed in the sql file
-    fuel_type = ['Electricity', 'Natural Gas', 'Additional Fuel', 'District Cooling', 'District Heating', 'Water']
+    fuel_type = fuel_types.values
 
     # get enduses as listed in the sql file
-    enduses = ['Heating', 'Cooling', 'Interior Lighting', 'Exterior Lighting', 'Interior Equipment', 'Exterior Equipment', 'Fans', 'Pumps',
-               'Heat Rejection', 'Humidification', 'Heat Recovery', 'Water Systems', 'Refrigeration', 'Generators']
+    enduses = end_uses.values
+    enduses.delete('Facility')
 
     # loop through fuel types and enduses to fill in sql_query method
     fuel_type.each do |ft|

--- a/lib/measures/default_feature_reports/measure.rb
+++ b/lib/measures/default_feature_reports/measure.rb
@@ -232,7 +232,7 @@ class DefaultFeatureReports < OpenStudio::Measure::ReportingMeasure
       end
     end
 
-    val
+    return val
   end
 
   # unit conversion method
@@ -577,12 +577,20 @@ class DefaultFeatureReports < OpenStudio::Measure::ReportingMeasure
     feature_report.reporting_periods[0].natural_gas_kwh = convert_units(natural_gas, 'GJ', 'kWh')
 
     # propane
+    propane = 0.0
     propane = sql_query(runner, sql_file, 'EnergyMeters', "TableName='Annual and Peak Values - Other' AND RowName='Propane:Facility' AND ColumnName='Annual Value'")
-    feature_report.reporting_periods[0].propane_kwh = convert_units(propane, 'GJ', 'kWh')
+    feature_report.reporting_periods[0].propane_kwh = convert_units(propane, 'GJ', 'kWh') unless propane.nil?
 
-    # additional_fuel
+    # fuel_oil
+    fuel_oil = 0.0
+    fuel_oil = sql_query(runner, sql_file, 'EnergyMeters', "TableName='Annual and Peak Values - Other' AND RowName='FuelOil#2:Facility' AND ColumnName='Annual Value'")
+    feature_report.reporting_periods[0].fuel_oil_kwh = convert_units(fuel_oil, 'GJ', 'kWh') unless fuel_oil.nil?
+
+    # other_fuels
     additional_fuel = sql_query(runner, sql_file, 'AnnualBuildingUtilityPerformanceSummary', "TableName='End Uses' AND RowName='Total End Uses' AND ColumnName='Additional Fuel'")
-    feature_report.reporting_periods[0].additional_fuel_kwh = convert_units(additional_fuel, 'GJ', 'kWh')
+    feature_report.reporting_periods[0].other_fuels_kwh = convert_units(additional_fuel, 'GJ', 'kWh')
+    feature_report.reporting_periods[0].other_fuels_kwh -= feature_report.reporting_periods[0].propane_kwh
+    feature_report.reporting_periods[0].other_fuels_kwh -= feature_report.reporting_periods[0].fuel_oil_kwh
 
     # district_cooling
     district_cooling = sql_query(runner, sql_file, 'AnnualBuildingUtilityPerformanceSummary', "TableName='End Uses' AND RowName='Total End Uses' AND ColumnName='District Cooling'")

--- a/lib/measures/default_feature_reports/measure.xml
+++ b/lib/measures/default_feature_reports/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>default_feature_reports</name>
   <uid>9ee3135a-8070-4408-bfa1-b75fecf9dd4f</uid>
-  <version_id>1f4eb28d-d586-4c10-8d23-f3495054ce1e</version_id>
-  <version_modified>20200921T204602Z</version_modified>
+  <version_id>f9af7bd8-e9ce-41b4-b892-df29f235a9bd</version_id>
+  <version_modified>20201201T173130Z</version_modified>
   <xml_checksum>FB304155</xml_checksum>
   <class_name>DefaultFeatureReports</class_name>
   <display_name>DefaultFeatureReports</display_name>
@@ -127,16 +127,22 @@
       <checksum>CC4BFFAF</checksum>
     </file>
     <file>
+      <filename>README.md</filename>
+      <filetype>md</filetype>
+      <usage_type>readme</usage_type>
+      <checksum>0B68E96D</checksum>
+    </file>
+    <file>
       <filename>LICENSE.md</filename>
       <filetype>md</filetype>
       <usage_type>license</usage_type>
-      <checksum>D8541540</checksum>
+      <checksum>BBD19F47</checksum>
     </file>
     <file>
       <filename>default_feature_reports_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>A5706600</checksum>
+      <checksum>19681175</checksum>
     </file>
     <file>
       <version>
@@ -147,13 +153,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>3C7B646E</checksum>
-    </file>
-    <file>
-      <filename>README.md</filename>
-      <filetype>md</filetype>
-      <usage_type>readme</usage_type>
-      <checksum>0B68E96D</checksum>
+      <checksum>B1E43E26</checksum>
     </file>
   </files>
 </measure>

--- a/lib/measures/default_feature_reports/tests/default_feature_reports_test.rb
+++ b/lib/measures/default_feature_reports/tests/default_feature_reports_test.rb
@@ -1,5 +1,5 @@
 # *********************************************************************************
-# URBANopt™, Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC, and other
+# URBANopt (tm), Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC, and other
 # contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,

--- a/lib/urbanopt/reporting/default_reports/end_uses.rb
+++ b/lib/urbanopt/reporting/default_reports/end_uses.rb
@@ -54,7 +54,7 @@ module URBANopt
           @electricity_kwh = EndUse.new(hash[:electricity_kwh])
           @natural_gas_kwh = EndUse.new(hash[:natural_gas_kwh])
           @propane_kwh = EndUse.new(hash[:propane_kwh])
-          @fuel_oil_kwh = EndUse.new(has[:fuel_oil_kwh])
+          @fuel_oil_kwh = EndUse.new(hash[:fuel_oil_kwh])
           @other_fuels_kwh = EndUse.new(hash[:other_fuels_kwh])
           @district_cooling_kwh = EndUse.new(hash[:district_cooling_kwh])
           @district_heating_kwh = EndUse.new(hash[:district_heating_kwh])

--- a/lib/urbanopt/reporting/default_reports/end_uses.rb
+++ b/lib/urbanopt/reporting/default_reports/end_uses.rb
@@ -39,9 +39,9 @@ module URBANopt
       # Enduses class inlclude results for each fuel type.
       ##
       class EndUses
-        attr_accessor :electricity_kwh, :natural_gas_kwh, :propane_kwh, :additional_fuel_kwh, :district_cooling_kwh, :district_heating_kwh, :water_qbft # :nodoc:
+        attr_accessor :electricity_kwh, :natural_gas_kwh, :propane_kwh, :fuel_oil_kwh, :other_fuels_kwh, :district_cooling_kwh, :district_heating_kwh, :water_qbft # :nodoc:
         ##
-        # EndUses class intialize end_uses(fuel type) attributes: +:electricity_kwh+ , +:natural_gas_kwh+ , +:propane_kwh+ , +:additional_fuel_kwh+ ,
+        # EndUses class intialize end_uses(fuel type) attributes: +:electricity_kwh+ , +:natural_gas_kwh+ , +:propane_kwh+ , +:fuel_oil_kwh+ , +:other_fuels_kwh+ ,
         # +:district_cooling_kwh+ , +:district_heating_kwh+ , +:water_qbft+
         ##
         # [parameters:]
@@ -54,7 +54,8 @@ module URBANopt
           @electricity_kwh = EndUse.new(hash[:electricity_kwh])
           @natural_gas_kwh = EndUse.new(hash[:natural_gas_kwh])
           @propane_kwh = EndUse.new(hash[:propane_kwh])
-          @additional_fuel_kwh = EndUse.new(hash[:additional_fuel_kwh])
+          @fuel_oil_kwh = EndUse.new(has[:fuel_oil_kwh])
+          @other_fuels_kwh = EndUse.new(hash[:other_fuels_kwh])
           @district_cooling_kwh = EndUse.new(hash[:district_cooling_kwh])
           @district_heating_kwh = EndUse.new(hash[:district_heating_kwh])
           @water_qbft = EndUse.new(hash[:water_qbft])
@@ -85,9 +86,13 @@ module URBANopt
           propane_kwh_hash.delete_if { |k, v| v.nil? }
           result[:propane_kwh] = propane_kwh_hash if @propane_kwh
 
-          additional_fuel_kwh_hash = @additional_fuel_kwh.to_hash if @additional_fuel_kwh
-          additional_fuel_kwh_hash.delete_if { |k, v| v.nil? }
-          result[:additional_fuel_kwh] = additional_fuel_kwh_hash if @additional_fuel_kwh
+          fuel_oil_kwh_hash = @fuel_oil_kwh.to_hash if @fuel_oil_kwh
+          fuel_oil_kwh_hash.delete_if { |k, v| v.nil? }
+          result[:fuel_oil_kwh] = fuel_oil_kwh_hash if @fuel_oil_kwh
+
+          other_fuels_kwh_hash = @other_fuels_kwh.to_hash if @other_fuels_kwh
+          other_fuels_kwh_hash.delete_if { |k, v| v.nil? }
+          result[:other_fuels_kwh] = other_fuels_kwh_hash if @other_fuels_kwh
 
           district_cooling_kwh_hash = @district_cooling_kwh.to_hash if @district_cooling_kwh
           district_cooling_kwh_hash.delete_if { |k, v| v.nil? }
@@ -117,7 +122,8 @@ module URBANopt
           hash[:electricity_kwh] = EndUse.new.to_hash
           hash[:natural_gas_kwh] = EndUse.new.to_hash
           hash[:propane_kwh] = EndUse.new.to_hash
-          hash[:additional_fuel_kwh] = EndUse.new.to_hash
+          hash[:fuel_oil_kwh] = EndUse.new.to_hash
+          hash[:other_fuels_kwh] = EndUse.new.to_hash
           hash[:district_cooling_kwh] = EndUse.new.to_hash
           hash[:district_heating_kwh] = EndUse.new.to_hash
           hash[:water_qbft] = EndUse.new.to_hash
@@ -136,7 +142,8 @@ module URBANopt
           @electricity_kwh.merge_end_use!(new_end_uses.electricity_kwh)
           @natural_gas_kwh.merge_end_use!(new_end_uses.natural_gas_kwh)
           @propane_kwh.merge_end_use!(new_end_uses.propane_kwh)
-          @additional_fuel_kwh.merge_end_use!(new_end_uses.additional_fuel_kwh)
+          @fuel_oil_kwh.merge_end_use!(new_end_uses.fuel_oil_kwh)
+          @other_fuels_kwh.merge_end_use!(new_end_uses.other_fuels_kwh)
           @district_cooling_kwh.merge_end_use!(new_end_uses.district_cooling_kwh)
           @district_heating_kwh.merge_end_use!(new_end_uses.district_heating_kwh)
           return self

--- a/lib/urbanopt/reporting/default_reports/end_uses.rb
+++ b/lib/urbanopt/reporting/default_reports/end_uses.rb
@@ -39,9 +39,9 @@ module URBANopt
       # Enduses class inlclude results for each fuel type.
       ##
       class EndUses
-        attr_accessor :electricity_kwh, :natural_gas_kwh, :additional_fuel_kwh, :district_cooling_kwh, :district_heating_kwh, :water_qbft # :nodoc:
+        attr_accessor :electricity_kwh, :natural_gas_kwh, :propane_kwh, :additional_fuel_kwh, :district_cooling_kwh, :district_heating_kwh, :water_qbft # :nodoc:
         ##
-        # EndUses class intialize end_uses(fuel type) attributes: +:electricity_kwh+ , +:natural_gas_kwh+ , +:additional_fuel_kwh+ ,
+        # EndUses class intialize end_uses(fuel type) attributes: +:electricity_kwh+ , +:natural_gas_kwh+ , +:propane_kwh+ , +:additional_fuel_kwh+ ,
         # +:district_cooling_kwh+ , +:district_heating_kwh+ , +:water_qbft+
         ##
         # [parameters:]
@@ -53,6 +53,7 @@ module URBANopt
 
           @electricity_kwh = EndUse.new(hash[:electricity_kwh])
           @natural_gas_kwh = EndUse.new(hash[:natural_gas_kwh])
+          @propane_kwh = EndUse.new(hash[:propane_kwh])
           @additional_fuel_kwh = EndUse.new(hash[:additional_fuel_kwh])
           @district_cooling_kwh = EndUse.new(hash[:district_cooling_kwh])
           @district_heating_kwh = EndUse.new(hash[:district_heating_kwh])
@@ -72,13 +73,17 @@ module URBANopt
         def to_hash
           result = {}
 
-          electricity_kwh_hash = @electricity_kwh.to_hash if @electricity_kwh.to_hash
+          electricity_kwh_hash = @electricity_kwh.to_hash if @electricity_kwh
           electricity_kwh_hash.delete_if { |k, v| v.nil? }
           result[:electricity_kwh] = electricity_kwh_hash if @electricity_kwh
 
           natural_gas_kwh_hash = @natural_gas_kwh.to_hash if @natural_gas_kwh
           natural_gas_kwh_hash.delete_if { |k, v| v.nil? }
           result[:natural_gas_kwh] = natural_gas_kwh_hash if @natural_gas_kwh
+
+          propane_kwh_hash = @propane_kwh.to_hash if @propane_kwh
+          propane_kwh_hash.delete_if { |k, v| v.nil? }
+          result[:propane_kwh] = propane_kwh_hash if @propane_kwh
 
           additional_fuel_kwh_hash = @additional_fuel_kwh.to_hash if @additional_fuel_kwh
           additional_fuel_kwh_hash.delete_if { |k, v| v.nil? }
@@ -111,6 +116,7 @@ module URBANopt
           hash = {}
           hash[:electricity_kwh] = EndUse.new.to_hash
           hash[:natural_gas_kwh] = EndUse.new.to_hash
+          hash[:propane_kwh] = EndUse.new.to_hash
           hash[:additional_fuel_kwh] = EndUse.new.to_hash
           hash[:district_cooling_kwh] = EndUse.new.to_hash
           hash[:district_heating_kwh] = EndUse.new.to_hash
@@ -129,6 +135,7 @@ module URBANopt
           # modify the existing_period by summing up the results ; # sum results only if they exist
           @electricity_kwh.merge_end_use!(new_end_uses.electricity_kwh)
           @natural_gas_kwh.merge_end_use!(new_end_uses.natural_gas_kwh)
+          @propane_kwh.merge_end_use!(new_end_uses.propane_kwh)
           @additional_fuel_kwh.merge_end_use!(new_end_uses.additional_fuel_kwh)
           @district_cooling_kwh.merge_end_use!(new_end_uses.district_cooling_kwh)
           @district_heating_kwh.merge_end_use!(new_end_uses.district_heating_kwh)

--- a/lib/urbanopt/reporting/default_reports/reporting_period.rb
+++ b/lib/urbanopt/reporting/default_reports/reporting_period.rb
@@ -44,13 +44,13 @@ module URBANopt
       ##
       class ReportingPeriod
         attr_accessor :id, :name, :multiplier, :start_date, :end_date, :month, :day_of_month, :year, :total_site_energy_kwh, :total_source_energy_kwh,
-                      :net_site_energy_kwh, :net_source_energy_kwh, :total_utility_cost_dollar, :net_utility_cost_dollar, :utility_costs_dollar, :electricity_kwh, :natural_gas_kwh, :additional_fuel_kwh, :district_cooling_kwh,
+                      :net_site_energy_kwh, :net_source_energy_kwh, :total_utility_cost_dollar, :net_utility_cost_dollar, :utility_costs_dollar, :electricity_kwh, :natural_gas_kwh, :propane_kwh, :additional_fuel_kwh, :district_cooling_kwh,
                       :district_heating_kwh, :water_qbft, :electricity_produced_kwh, :end_uses, :energy_production_kwh, :photovoltaic,
                       :fuel_type, :total_cost_dollar, :usage_cost_dollar, :demand_cost_dollar, :comfort_result, :time_setpoint_not_met_during_occupied_cooling,
                       :time_setpoint_not_met_during_occupied_heating, :time_setpoint_not_met_during_occupied_hours, :hours_out_of_comfort_bounds_PMV, :hours_out_of_comfort_bounds_PPD #:nodoc:
         # ReportingPeriod class initializes the reporting period attributes:
         # +:id+ , +:name+ , +:multiplier+ , +:start_date+ , +:end_date+ , +:month+ , +:day_of_month+ , +:year+ , +:total_site_energy_kwh+ , +:total_source_energy_kwh+ ,
-        # +:net_site_energy_kwh+ , +:net_source_energy_kwh+ , +:total_utility_cost_dollar , +:net_utility_cost_dollar+ , +:utility_costs_dollar+ , +:electricity_kwh+ , +:natural_gas_kwh+ , +:additional_fuel_kwh+ , +:district_cooling_kwh+ ,
+        # +:net_site_energy_kwh+ , +:net_source_energy_kwh+ , +:total_utility_cost_dollar , +:net_utility_cost_dollar+ , +:utility_costs_dollar+ , +:electricity_kwh+ , +:natural_gas_kwh+ , +:propane_kwh+ , +:additional_fuel_kwh+ , +:district_cooling_kwh+ ,
         # +:district_heating_kwh+ , +:water_qbft+ , +:electricity_produced_kwh+ , +:end_uses+ , +:energy_production_kwh+ , +:photovoltaic_kwh+ ,
         # +:fuel_type+ , +:total_cost_dollar+ , +:usage_cost_dollar+ , +:demand_cost_dollar+ , +:comfort_result+ , +:time_setpoint_not_met_during_occupied_cooling+ ,
         # +:time_setpoint_not_met_during_occupied_heating+ , +:time_setpoint_not_met_during_occupied_hours+
@@ -76,6 +76,7 @@ module URBANopt
           @total_utility_cost_dollar = hash [:total_utility_cost_dollar]
           @electricity_kwh = hash [:electricity_kwh]
           @natural_gas_kwh = hash [:natural_gas_kwh]
+          @propane_kwh = hash [:propane_kwh]
           @additional_fuel_kwh = hash [:additional_fuel_kwh]
           @district_cooling_kwh = hash [:district_cooling_kwh]
           @district_heating_kwh = hash[:district_heating_kwh]
@@ -108,14 +109,15 @@ module URBANopt
 
           hash[:total_site_energy_kwh] = nil
           hash[:total_source_energy_kwh] = nil
-          hash [:net_site_energy_kwh] = nil
-          hash [:net_source_energy_kwh] = nil
-          hash [:net_utility_cost_dollar] = nil
-          hash [:total_utility_cost_dollar] = nil
-          hash [:electricity_kwh] = nil
-          hash [:natural_gas_kwh] = nil
-          hash [:additional_fuel_kwh] = nil
-          hash [:district_cooling_kwh] = nil
+          hash[:net_site_energy_kwh] = nil
+          hash[:net_source_energy_kwh] = nil
+          hash[:net_utility_cost_dollar] = nil
+          hash[:total_utility_cost_dollar] = nil
+          hash[:electricity_kwh] = nil
+          hash[:natural_gas_kwh] = nil
+          hash[:propane_kwh] = nil
+          hash[:additional_fuel_kwh] = nil
+          hash[:district_cooling_kwh] = nil
           hash[:district_heating_kwh] = nil
 
           hash[:electricity_produced_kwh] = nil
@@ -150,6 +152,7 @@ module URBANopt
           result[:total_utility_cost_dollar] = @total_utility_cost_dollar if @total_utility_cost_dollar
           result[:electricity_kwh] = @electricity_kwh if @electricity_kwh
           result[:natural_gas_kwh] = @natural_gas_kwh if @natural_gas_kwh
+          result[:propane_kwh] = @propane_kwh if @propane_kwh
           result[:additional_fuel_kwh] = @additional_fuel_kwh if @additional_fuel_kwh
           result[:district_cooling_kwh] = @district_cooling_kwh if @district_cooling_kwh
           result[:district_heating_kwh] = @district_heating_kwh if @district_heating_kwh
@@ -218,6 +221,7 @@ module URBANopt
           existing_period.total_utility_cost_dollar = add_values(existing_period.total_utility_cost_dollar, new_period.total_utility_cost_dollar)
           existing_period.electricity_kwh = add_values(existing_period.electricity_kwh, new_period.electricity_kwh)
           existing_period.natural_gas_kwh = add_values(existing_period.natural_gas_kwh, new_period.natural_gas_kwh)
+          existing_period.propane_kwh = add_values(existing_period.propane_kwh, new_period.propane_kwh)
           existing_period.additional_fuel_kwh = add_values(existing_period.additional_fuel_kwh, new_period.additional_fuel_kwh)
           existing_period.district_cooling_kwh = add_values(existing_period.district_cooling_kwh, new_period.district_cooling_kwh)
           existing_period.district_heating_kwh = add_values(existing_period.district_heating_kwh, new_period.district_heating_kwh)

--- a/lib/urbanopt/reporting/default_reports/reporting_period.rb
+++ b/lib/urbanopt/reporting/default_reports/reporting_period.rb
@@ -44,13 +44,13 @@ module URBANopt
       ##
       class ReportingPeriod
         attr_accessor :id, :name, :multiplier, :start_date, :end_date, :month, :day_of_month, :year, :total_site_energy_kwh, :total_source_energy_kwh,
-                      :net_site_energy_kwh, :net_source_energy_kwh, :total_utility_cost_dollar, :net_utility_cost_dollar, :utility_costs_dollar, :electricity_kwh, :natural_gas_kwh, :propane_kwh, :additional_fuel_kwh, :district_cooling_kwh,
+                      :net_site_energy_kwh, :net_source_energy_kwh, :total_utility_cost_dollar, :net_utility_cost_dollar, :utility_costs_dollar, :electricity_kwh, :natural_gas_kwh, :propane_kwh, :fuel_oil_kwh, :other_fuels_kwh, :district_cooling_kwh,
                       :district_heating_kwh, :water_qbft, :electricity_produced_kwh, :end_uses, :energy_production_kwh, :photovoltaic,
                       :fuel_type, :total_cost_dollar, :usage_cost_dollar, :demand_cost_dollar, :comfort_result, :time_setpoint_not_met_during_occupied_cooling,
                       :time_setpoint_not_met_during_occupied_heating, :time_setpoint_not_met_during_occupied_hours, :hours_out_of_comfort_bounds_PMV, :hours_out_of_comfort_bounds_PPD #:nodoc:
         # ReportingPeriod class initializes the reporting period attributes:
         # +:id+ , +:name+ , +:multiplier+ , +:start_date+ , +:end_date+ , +:month+ , +:day_of_month+ , +:year+ , +:total_site_energy_kwh+ , +:total_source_energy_kwh+ ,
-        # +:net_site_energy_kwh+ , +:net_source_energy_kwh+ , +:total_utility_cost_dollar , +:net_utility_cost_dollar+ , +:utility_costs_dollar+ , +:electricity_kwh+ , +:natural_gas_kwh+ , +:propane_kwh+ , +:additional_fuel_kwh+ , +:district_cooling_kwh+ ,
+        # +:net_site_energy_kwh+ , +:net_source_energy_kwh+ , +:total_utility_cost_dollar , +:net_utility_cost_dollar+ , +:utility_costs_dollar+ , +:electricity_kwh+ , +:natural_gas_kwh+ , +:propane_kwh+ , +:fuel_oil_kwh+ , +:other_fuels_kwh+ , +:district_cooling_kwh+ ,
         # +:district_heating_kwh+ , +:water_qbft+ , +:electricity_produced_kwh+ , +:end_uses+ , +:energy_production_kwh+ , +:photovoltaic_kwh+ ,
         # +:fuel_type+ , +:total_cost_dollar+ , +:usage_cost_dollar+ , +:demand_cost_dollar+ , +:comfort_result+ , +:time_setpoint_not_met_during_occupied_cooling+ ,
         # +:time_setpoint_not_met_during_occupied_heating+ , +:time_setpoint_not_met_during_occupied_hours+
@@ -70,15 +70,16 @@ module URBANopt
 
           @total_site_energy_kwh = hash[:total_site_energy_kwh]
           @total_source_energy_kwh = hash[:total_source_energy_kwh]
-          @net_site_energy_kwh = hash [:net_site_energy_kwh]
-          @net_source_energy_kwh = hash [:net_source_energy_kwh]
-          @net_utility_cost_dollar = hash [:net_utility_cost_dollar]
-          @total_utility_cost_dollar = hash [:total_utility_cost_dollar]
-          @electricity_kwh = hash [:electricity_kwh]
-          @natural_gas_kwh = hash [:natural_gas_kwh]
-          @propane_kwh = hash [:propane_kwh]
-          @additional_fuel_kwh = hash [:additional_fuel_kwh]
-          @district_cooling_kwh = hash [:district_cooling_kwh]
+          @net_site_energy_kwh = hash[:net_site_energy_kwh]
+          @net_source_energy_kwh = hash[:net_source_energy_kwh]
+          @net_utility_cost_dollar = hash[:net_utility_cost_dollar]
+          @total_utility_cost_dollar = hash[:total_utility_cost_dollar]
+          @electricity_kwh = hash[:electricity_kwh]
+          @natural_gas_kwh = hash[:natural_gas_kwh]
+          @propane_kwh = hash[:propane_kwh]
+          @fuel_oil_kwh = hash[:fuel_oil_kwh]
+          @other_fuels_kwh = hash[:other_fuels_kwh]
+          @district_cooling_kwh = hash[:district_cooling_kwh]
           @district_heating_kwh = hash[:district_heating_kwh]
           @water_qbft = hash[:water_qbft]
           @electricity_produced_kwh = hash[:electricity_produced_kwh]
@@ -116,7 +117,8 @@ module URBANopt
           hash[:electricity_kwh] = nil
           hash[:natural_gas_kwh] = nil
           hash[:propane_kwh] = nil
-          hash[:additional_fuel_kwh] = nil
+          hash[:fuel_oil_kwh] = nil
+          hash[:other_fuels_kwh] = nil
           hash[:district_cooling_kwh] = nil
           hash[:district_heating_kwh] = nil
 
@@ -153,7 +155,8 @@ module URBANopt
           result[:electricity_kwh] = @electricity_kwh if @electricity_kwh
           result[:natural_gas_kwh] = @natural_gas_kwh if @natural_gas_kwh
           result[:propane_kwh] = @propane_kwh if @propane_kwh
-          result[:additional_fuel_kwh] = @additional_fuel_kwh if @additional_fuel_kwh
+          result[:fuel_oil_kwh] = @fuel_oil_kwh if @fuel_oil_kwh
+          result[:other_fuels_kwh] = @other_fuels_kwh if @other_fuels_kwh
           result[:district_cooling_kwh] = @district_cooling_kwh if @district_cooling_kwh
           result[:district_heating_kwh] = @district_heating_kwh if @district_heating_kwh
           result[:water_qbft] = @water_qbft if @water_qbft
@@ -222,7 +225,8 @@ module URBANopt
           existing_period.electricity_kwh = add_values(existing_period.electricity_kwh, new_period.electricity_kwh)
           existing_period.natural_gas_kwh = add_values(existing_period.natural_gas_kwh, new_period.natural_gas_kwh)
           existing_period.propane_kwh = add_values(existing_period.propane_kwh, new_period.propane_kwh)
-          existing_period.additional_fuel_kwh = add_values(existing_period.additional_fuel_kwh, new_period.additional_fuel_kwh)
+          existing_period.fuel_oil_kwh = add_values(existing_period.fuel_oil_kwh, new_period.fuel_oil_kwh)
+          existing_period.other_fuels_kwh = add_values(existing_period.other_fuels_kwh, new_period.other_fuels_kwh)
           existing_period.district_cooling_kwh = add_values(existing_period.district_cooling_kwh, new_period.district_cooling_kwh)
           existing_period.district_heating_kwh = add_values(existing_period.district_heating_kwh, new_period.district_heating_kwh)
           existing_period.water_qbft = add_values(existing_period.water_qbft, new_period.water_qbft)

--- a/lib/urbanopt/reporting/default_reports/schema/scenario_csv_columns.txt
+++ b/lib/urbanopt/reporting/default_reports/schema/scenario_csv_columns.txt
@@ -3,7 +3,8 @@ Electricity:Facility
 ElectricityProduced:Facility
 Gas:Facility
 Propane:Facility
-FuelOil:Facility
+FuelOil#2:Facility
+OtherFuels:Facility
 Cooling:Electricity
 Heating:Electricity
 InteriorLights:Electricity
@@ -25,6 +26,10 @@ HeatRejection:FuelOil
 Heating:FuelOil
 WaterSystems:FuelOil
 InteriorEquipment:FuelOil
+HeatRejection:OtherFuels
+Heating:OtherFuels
+WaterSystems:OtherFuels
+InteriorEquipment:OtherFuels
 DistrictCooling:Facility
 DistrictHeating:Facility
 District Cooling Chilled Water Rate

--- a/lib/urbanopt/reporting/default_reports/schema/scenario_csv_columns.txt
+++ b/lib/urbanopt/reporting/default_reports/schema/scenario_csv_columns.txt
@@ -22,10 +22,10 @@ HeatRejection:Propane
 Heating:Propane
 WaterSystems:Propane
 InteriorEquipment:Propane
-HeatRejection:FuelOil
-Heating:FuelOil
-WaterSystems:FuelOil
-InteriorEquipment:FuelOil
+HeatRejection:FuelOil#2
+Heating:FuelOil#2
+WaterSystems:FuelOil#2
+InteriorEquipment:FuelOil#2
 HeatRejection:OtherFuels
 Heating:OtherFuels
 WaterSystems:OtherFuels

--- a/lib/urbanopt/reporting/default_reports/schema/scenario_csv_columns.txt
+++ b/lib/urbanopt/reporting/default_reports/schema/scenario_csv_columns.txt
@@ -2,6 +2,8 @@ Datetime
 Electricity:Facility
 ElectricityProduced:Facility
 Gas:Facility
+Propane:Facility
+FuelOil:Facility
 Cooling:Electricity
 Heating:Electricity
 InteriorLights:Electricity
@@ -15,6 +17,14 @@ HeatRejection:Gas
 Heating:Gas
 WaterSystems:Gas
 InteriorEquipment:Gas
+HeatRejection:Propane
+Heating:Propane
+WaterSystems:Propane
+InteriorEquipment:Propane
+HeatRejection:FuelOil
+Heating:FuelOil
+WaterSystems:FuelOil
+InteriorEquipment:FuelOil
 DistrictCooling:Facility
 DistrictHeating:Facility
 District Cooling Chilled Water Rate

--- a/lib/urbanopt/reporting/default_reports/schema/scenario_schema.json
+++ b/lib/urbanopt/reporting/default_reports/schema/scenario_schema.json
@@ -310,7 +310,7 @@
 					"type": "number"
         },
 				"other_fuels_kwh": {
-					"description": "Sum of all other fuel end uses consumption (kWh)",
+					"description": "Sum of all other (fuel oil #1, diesel, gasoline, coal, steam) fuel end uses consumption (kWh)",
 					"type": "number"
 				},
 				"district_cooling_kwh": {

--- a/lib/urbanopt/reporting/default_reports/schema/scenario_schema.json
+++ b/lib/urbanopt/reporting/default_reports/schema/scenario_schema.json
@@ -305,8 +305,12 @@
 					"description": "Sum of all propane end uses consumption (kWh)",
 					"type": "number"
         },
-				"additional_fuel_kwh": {
-					"description": "Sum of all additional fuel end uses consumption (kWh)",
+        "fuel_oil_kwh": {
+					"description": "Sum of all fuel oil #2 end uses consumption (kWh)",
+					"type": "number"
+        },
+				"other_fuels_kwh": {
+					"description": "Sum of all other fuel end uses consumption (kWh)",
 					"type": "number"
 				},
 				"district_cooling_kwh": {
@@ -378,7 +382,10 @@
         "propane_kwh": {
           "$ref": "#/definitions/EndUse"
         },
-				"additional_fuel_kwh": {
+        "fuel_oil_kwh": {
+          "$ref": "#/definitions/EndUse"
+        },
+				"other_fuels_kwh": {
 					"$ref": "#/definitions/EndUse"
 				},
 				"district_cooling_kwh": {
@@ -530,9 +537,10 @@
 						"Electricity",
 						"Natural Gas",
             "Propane",
+            "Fuel Oil",
 						"District Cooling",
 						"District Heating",
-						"Additional Fuel",
+						"Other Fuels",
 						"Water"
 					]
 				},

--- a/lib/urbanopt/reporting/default_reports/schema/scenario_schema.json
+++ b/lib/urbanopt/reporting/default_reports/schema/scenario_schema.json
@@ -301,6 +301,10 @@
 					"description": "Sum of all natural gas end uses consumption (kWh)",
 					"type": "number"
 				},
+        "propane_kwh": {
+					"description": "Sum of all propane end uses consumption (kWh)",
+					"type": "number"
+        },
 				"additional_fuel_kwh": {
 					"description": "Sum of all additional fuel end uses consumption (kWh)",
 					"type": "number"
@@ -371,6 +375,9 @@
 				"natural_gas_kwh": {
 					"$ref": "#/definitions/EndUse"
 				},
+        "propane_kwh": {
+          "$ref": "#/definitions/EndUse"
+        },
 				"additional_fuel_kwh": {
 					"$ref": "#/definitions/EndUse"
 				},
@@ -522,6 +529,7 @@
 					"enum": [
 						"Electricity",
 						"Natural Gas",
+            "Propane",
 						"District Cooling",
 						"District Heating",
 						"Additional Fuel",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 # *********************************************************************************
-# URBANopt™, Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC, and other
+# URBANopt (tm), Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC, and other
 # contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,

--- a/spec/urbanopt/reporting/reporting_spec.rb
+++ b/spec/urbanopt/reporting/reporting_spec.rb
@@ -1,5 +1,5 @@
 # *********************************************************************************
-# URBANopt™, Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC, and other
+# URBANopt (tm), Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC, and other
 # contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,


### PR DESCRIPTION
### Pull Request Description

Support for reporting:
* propane
* fuel oil (no. 2)
* other fuels (calculated as `additional fuel - (propane + fuel oil)`)

Also:
* Zero out district heating/cooling for Single-Family Detached

TODO:
 - [x] Include `OtherFuels:Facility`, `HeaRejection:OtherFuels`, `Heating:OtherFuels`, `WaterSystems:OtherFuels`, `InteriorEquipment:OtherFuels` in timeseries
 - [x] Zero out district heating/cooling in timeseries
 - [ ] Check that post-processing does not break (https://github.com/urbanopt/urbanopt-example-geojson-project/tree/other-fuels)
   - [ ] `post_process_baseline`: runs but FuelOil#2 not in default_scenario_report.csv
   - [ ] `visualize_features`: runs but Propane, FuelOil#2, OtherFuels not shown
   - [ ] `visualize_scenarios`: runs but Propane, FuelOil#2, OtherFuels not shown

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] Documentation has been modified appropriately
- [ ] All ci tests pass (green)
- [ ] An [ISSUE](https://github.com/urbanopt/urbanopt-reporting-gem/issues) has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run.
- [ ] This branch is up-to-date with develop
