### PR TITLE
make subfolders in feature saving if necessary

### DIFF
--- a/lib/urbanopt/reporting/default_reports/feature_report.rb
+++ b/lib/urbanopt/reporting/default_reports/feature_report.rb
@@ -40,6 +40,7 @@ require_relative  'thermal_storage'
 
 require 'json-schema'
 require 'json'
+require 'fileutils'
 
 module URBANopt
   module Reporting
@@ -244,6 +245,7 @@ module URBANopt
           Dir.mkdir(results_dir_path) unless Dir.exist?(File.join(@directory_name, 'feature_reports'))
 
           @timeseries_csv.path = File.join(@directory_name, 'feature_reports', file_name + '.csv')
+          FileUtils.mkdir_p File.dirname(@timeseries_csv.path)
           @timeseries_csv.save_data
 
           ## save json rport


### PR DESCRIPTION
### Resolves #53 

### Pull Request Description

Addresses cases where users may want to save feature reports within folders (i.e. to avoid delete issues on CI)

### Checklist (Delete lines that don't apply)

- [x] All ci tests pass (green)
- [x] An [ISSUE](https://github.com/urbanopt/urbanopt-reporting-gem/issues) has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run.
- [x] This branch is up-to-date with develop
