### PR TITLE
set up actions with coveralls

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -38,4 +38,4 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: "./coverage/lcov/urbanopt-scenario-gem.lcov"
+          path-to-lcov: "./coverage/lcov/urbanopt-reporting-gem.lcov"

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,11 +1,11 @@
 name: nightly_build
 
 on:
-  push:
-  # schedule:
+  # push:
+  schedule:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
     # 5 am UTC (11pm MDT the day before) every weekday night in MDT
-    # - cron: '21 5 * * 2-6'
+    - cron: '22 5 * * 2-6'
 
 # Cancels an existing job (of the same workflow) if it is still running
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,0 +1,41 @@
+name: nightly_build
+
+on:
+  push:
+  # schedule:
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+    # 5 am UTC (11pm MDT the day before) every weekday night in MDT
+    # - cron: '21 5 * * 2-6'
+
+# Cancels an existing job (of the same workflow) if it is still running
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#   cancel-in-progress: true
+
+env:
+  # This env var should enforce develop branch of all dependencies
+  FAVOR_LOCAL_GEMS: true
+  GEM_DEVELOPER_KEY: ${{ secrets.GEM_DEVELOPER_KEY }}
+
+jobs:
+  weeknight-tests:
+    # Pinned to `ubuntu-20.04`. When ubuntu-latest adopts 22.04 it would break for us since 22 only supports Ruby 3.1
+    # https://github.com/ruby/setup-ruby#supported-platforms
+    runs-on: ubuntu-20.04
+    container:
+      image: docker://nrel/openstudio:3.4.0
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Update gems
+        run: |
+          bundle update
+      - name: Run Rspec
+        run: bundle exec rspec
+      # coveralls action docs: https://github.com/marketplace/actions/coveralls-github-action
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: "./coverage/lcov/urbanopt-scenario-gem.lcov"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # URBANopt Reporting Gem
 
+[![Coverage Status](https://coveralls.io/repos/github/urbanopt/urbanopt-reporting-gem/badge.svg?branch=github-actions-coveralls)](https://coveralls.io/github/urbanopt/urbanopt-reporting-gem?branch=github-actions-coveralls)
+
 The URBANopt<sup>&trade;</sup> Reporting Gem defines the URABNopt reports (Scenario and Feature reports). It also includes the default reporting measure which query results from the energyplus sql database and reports it in the Feature reports.
 
 
@@ -27,9 +29,9 @@ Or install it yourself as:
 Check out the repository and then execute:
 
     $ bundle install
-    $ bundle update    
+    $ bundle update
     $ bundle exec rake
-    
+
 ## Releasing
 
 * Update CHANGELOG.md

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,16 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 # *********************************************************************************
 
+require 'simplecov'
+require 'simplecov-lcov'
+
+SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+# Don't consider the spec folder for test coverage reporting (inside the do/end loop)
+SimpleCov.start do
+  add_filter '/spec/'
+end
+
 require 'bundler/setup'
 require 'urbanopt/reporting'
 

--- a/urbanopt-reporting-gem.gemspec
+++ b/urbanopt-reporting-gem.gemspec
@@ -26,6 +26,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 2.1.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
+  spec.add_development_dependency 'simplecov', '~> 0.18.2'
+  spec.add_development_dependency 'simplecov-lcov', '~> 0.8.0'
+
   spec.add_runtime_dependency 'json_pure', '~> 2.3'
   spec.add_runtime_dependency 'json-schema', '~> 2.8'
   spec.add_runtime_dependency 'openstudio-extension', '~> 0.5.1'


### PR DESCRIPTION
### Resolves #117 

### Pull Request Description

Adds Github action to run all tests via rspec and report coverage via Coveralls. Syntax is copied from geojson-gem.

### Checklist (Delete lines that don't apply)

- [x] All ci tests pass (green)
- [x] An [ISSUE](https://github.com/urbanopt/urbanopt-reporting-gem/issues) has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run.
- [x] This branch is up-to-date with develop
