### PR TITLE
don't use local gem in nightly ci build any more

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   # This env var should enforce develop branch of all dependencies
-  FAVOR_LOCAL_GEMS: true
+  FAVOR_LOCAL_GEMS: false
   GEM_DEVELOPER_KEY: ${{ secrets.GEM_DEVELOPER_KEY }}
 
 jobs:


### PR DESCRIPTION
### Pull Request Description

`Favor_local_gems` env var set to false.

The nightly build on GitHubActions still had the `Favor_local_gems` env var set to true. That was set for setup and testing of coveralls in the nightly build and is not longer appropriate.

### Checklist (Delete lines that don't apply)

- [ ] All ci tests pass (green)
- [ ] This branch is up-to-date with develop
