### PR TITLE
update gha ci to use openstudio 3.5.1

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -20,17 +20,15 @@ env:
 
 jobs:
   weeknight-tests:
-    # Pinned to `ubuntu-20.04`. When ubuntu-latest adopts 22.04 it would break for us since 22 only supports Ruby 3.1
-    # https://github.com/ruby/setup-ruby#supported-platforms
-    runs-on: ubuntu-20.04
+    # ubuntu-latest works since https://github.com/rbenv/ruby-build/releases/tag/v20220710 (July 10, 2022)
+    # https://github.com/rbenv/ruby-build/discussions/1940
+    runs-on: ubuntu-latest
     container:
-      image: docker://nrel/openstudio:3.4.0
+      image: docker://nrel/openstudio:3.5.1
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
       - name: Update gems
-        run: |
-          bundle update
+        run: bundle update
       - name: Run Rspec
         run: bundle exec rspec
       # coveralls action docs: https://github.com/marketplace/actions/coveralls-github-action


### PR DESCRIPTION
### Pull Request Description

Use OpenStudio 3.5.1 in GitHub Actions

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] Documentation has been modified appropriately
- [ ] All ci tests pass (green)
- [ ] An [ISSUE](https://github.com/urbanopt/urbanopt-reporting-gem/issues) has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run.
- [ ] This branch is up-to-date with develop
