### PR TITLE
pin `addressable` to version 2.8.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,9 @@ gemspec
 # checkout the latest version (develop) from github.
 allow_local = ENV['FAVOR_LOCAL_GEMS']
 
+# pin this dependency to avoid unicode_normalize error
+gem 'addressable', '2.8.1'
+
 # if allow_local && File.exist?('../openstudio-extension-gem')
 #   gem 'openstudio-extension', path: '../openstudio-extension-gem'
 # elsif allow_local


### PR DESCRIPTION
### Pull Request Description

Does what it says on the tin. Addressable was changed in 2.8.2 in a way that doesn't work for OpenStudio. We first handled this in [this issue](https://github.com/urbanopt/urbanopt-cli/issues/416) from the urbanopt-cli.

This is required so `rake openstudio:test_with_openstudio` works.

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] Documentation has been modified appropriately
- [ ] All ci tests pass (green)
- [ ] An [ISSUE](https://github.com/urbanopt/urbanopt-reporting-gem/issues) has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run.
- [ ] This branch is up-to-date with develop
