### PR TITLE
fix schema typos and errors

### DIFF
--- a/lib/urbanopt/reporting/default_reports/schema/scenario_schema.json
+++ b/lib/urbanopt/reporting/default_reports/schema/scenario_schema.json
@@ -1,1516 +1,1544 @@
 {
-	"$schema": "http://json-schema.org/draft-04/schema#",
-	"description": "Comment describing your JSON Schema",
-	"type": "object",
-	"properties": {
-		"scenario_report": {
-			"$ref": "#/definitions/ScenarioReport"
-		},
-		"feature_reports": {
-			"description": "features of each data point in the scenario",
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/FeatureReport"
-			}
-		}
-	},
-	"required": [
-		"scenario_report"
-	],
-	"additionalProperties": false,
-	"definitions": {
-		"ScenarioReport": {
-			"type": "object",
-			"properties": {
-				"id": {
-					"type": "string"
-				},
-				"name": {
-					"type": "string"
-				},
-				"directory_name": {
-					"type": "string"
-				},
-				"timesteps_per_hour": {
-					"$ref": "#/definitions/TimestepsPerHour"
-				},
-				"number_of_not_started_simulations": {
-					"type": "number"
-				},
-				"number_of_started_simulations": {
-					"type": "number"
-				},
-				"number_of_complete_simulations": {
-					"type": "number"
-				},
-				"number_of_failed_simulations": {
-					"type": "number"
-				},
-				"location": {
-					"$ref": "#/definitions/Location"
-				},
-				"timeseries_csv": {
-					"$ref": "#/definitions/TimeseriesCSV"
-				},
-				"program": {
-					"$ref": "#/definitions/Program"
-				},
-				"construction_costs": {
-					"$ref": "#/definitions/ConstructionCosts"
-				},
-				"reporting_periods": {
-					"$ref": "#/definitions/ReportingPeriods"
-				},
-				"distributed_generation": {
-					"$ref": "#/definitions/DistributedGeneration"
-				},
-				"thermal_storage": {
-					"$ref": "#/definitions/ThermalStorage"
-				},
-				"rnm_results": {
-					"$ref": "#definitions/RnmResults"
-				},
-				"scenario_power_distribution": {
-					"$ref": "#definitions/ScenarioPowerDistribution"
-				},
-				"scenario_power_distribution_cost": {
-					"$ref": "#definitions/ScenarioPowerDistributionCost"
-				},
-				"qaqc_flags": {
-					"$ref": "#/definitions/qaqc_flags"
-				}
-			},
-			"required": [
-				"id",
-				"name",
-				"directory_name",
-				"timesteps_per_hour",
-				"number_of_not_started_simulations",
-				"number_of_started_simulations",
-				"number_of_complete_simulations",
-				"number_of_failed_simulations",
-				"program"
-			],
-			"additionalProperties": false
-		},
-		"ScenarioPowerDistribution": {
-			"type": "object",
-			"properties": {
-				"substations": {
-					"description": "Array of electrical substations",
-					"type": "array",
-					"items": {
-						"type": "object",
-						"properties": {
-							"nominal_voltage": {
-								"description": "Nominal Voltage (V)",
-								"type": "number"
-							}
-						}
-					}
-				},
-				"distribution_lines": {
-					"description": "Array of distribution lines",
-					"type": "array",
-					"items": {
-						"type": "object",
-						"properties": {
-							"length": {
-								"description": "Length of the line (m)",
-								"type": "number"
-							},
-							"ampacity": {
-								"description": "Maximum ampacity of the line (A)",
-								"type": "number"
-							},
-							"commercial_line_type": {
-								"description": "Array of the wire types that make up the line",
-								"type": "array",
-								"items": {
-									"type": "string"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"ScenarioPowerDistributionCost": {
-			"type": "object",
-			"properties": {
-				"title": "UpgradeParamsBaseModel",
-				"description": "Contains results from all jobs in the simulation.",
-				"type": "object",
-				"properties": {
-					"results": {
-						"title": "results",
-						"description": "Results summary for each job",
-						"type": "array",
-						"items": {}
-					},
-					"outputs": {
-						"title": "outputs",
-						"description": "Outputs for each job in the simulation.",
-						"allOf": [{
-							"$ref": "#/definitions/UpgradeSimulationOutputModel"
-						}]
-					},
-					"violation_summary": {
-						"title": "upgrade_summary",
-						"description": "Contains thermal or voltage upgrade results for each job",
-						"type": "array",
-						"items": {
-							"$ref": "#/definitions/UpgradeViolationResultModel"
-						}
-					},
-					"costs_per_equipment": {
-						"title": "costs_per_equipment",
-						"description": "Contains upgrade cost information for each job by equipment type",
-						"type": "array",
-						"items": {
-							"$ref": "#/definitions/TotalUpgradeCostsResultModel"
-						}
-					},
-					"equipment": {
-						"title": "equipment",
-						"description": "Contains equipment information for each job",
-						"type": "array",
-						"items": {}
-					}
-				},
-				"additionalProperties": false,
-				"definitions": {
-					"UpgradeJobOutputModel": {
-						"title": "UpgradeParamsBaseModel",
-						"description": "Contains outputs from one job.",
-						"type": "object",
-						"properties": {
-							"upgraded_opendss_model_file": {
-								"title": "upgraded_opendss_model_file",
-								"description": "Path to file that will load the upgraded network.",
-								"type": "string"
-							},
-							"feeder_stats": {
-								"title": "feeder_stats",
-								"description": "Path to file containing feeder metadata and equipment details before and after upgrades.",
-								"type": "string"
-							},
-							"return_code": {
-								"title": "return_code",
-								"description": "Return code from process. Zero is success, non-zero is a failure.",
-								"type": "integer"
-							}
-						},
-						"required": [
-							"upgraded_opendss_model_file",
-							"feeder_stats",
-							"return_code"
-						],
-						"additionalProperties": false
-					},
-					"UpgradeSimulationOutputModel": {
-						"title": "UpgradeParamsBaseModel",
-						"description": "Contains outputs from all jobs in the simulation.",
-						"type": "object",
-						"properties": {
-							"log_file": {
-								"title": "log_file",
-								"description": "Path to log file for the simulation.",
-								"type": "string"
-							},
-							"jobs": {
-								"title": "jobs",
-								"description": "Outputs for each job in the simulation.",
-								"type": "array",
-								"items": {
-									"$ref": "#/definitions/UpgradeJobOutputModel"
-								}
-							}
-						},
-						"required": [
-							"log_file",
-							"jobs"
-						],
-						"additionalProperties": false
-					},
-					"UpgradeViolationResultModel": {
-						"title": "UpgradeParamsBaseModel",
-						"description": "Defines result parameters for thermal upgrades.",
-						"type": "object",
-						"properties": {
-							"name": {
-								"title": "name",
-								"description": "Job name that produced the result",
-								"type": "string"
-							},
-							"scenario": {
-								"title": "scenario",
-								"description": "Simulation scenario describing the controls being used",
-								"default": "control_mode",
-								"type": "string"
-							},
-							"stage": {
-								"title": "stage",
-								"description": "Stage of upgrades: initial (before upgrades) or final (after upgrades)",
-								"type": "string"
-							},
-							"upgrade_type": {
-								"title": "upgrade_type",
-								"description": "Type of upgrade: thermal or voltage",
-								"type": "string"
-							},
-							"simulation_time_s": {
-								"title": "simulation_time_s",
-								"description": "Simulation time to perform upgrades (seconds)",
-								"type": "number"
-							},
-							"thermal_violations_present": {
-								"title": "thermal_violations_present",
-								"description": "Flag indicating whether thermal violations are present",
-								"type": "boolean"
-							},
-							"voltage_violations_present": {
-								"title": "voltage_violations_present",
-								"description": "Flag indicating whether voltage violations are present",
-								"type": "boolean"
-							},
-							"max_bus_voltage": {
-								"title": "max_bus_voltage",
-								"description": "Maximum voltage recorded on any bus",
-								"units": "pu",
-								"type": "number"
-							},
-							"min_bus_voltage": {
-								"title": "min_bus_voltage",
-								"description": "Minimum voltage recorded on any bus",
-								"units": "pu",
-								"type": "number"
-							},
-							"num_voltage_violation_buses": {
-								"title": "num_voltage_violation_buses",
-								"description": "Number of buses with voltage violations",
-								"type": "integer"
-							},
-							"num_overvoltage_violation_buses": {
-								"title": "num_overvoltage_violation_buses",
-								"description": "Number of buses with voltage above voltage_upper_limit",
-								"type": "integer"
-							},
-							"voltage_upper_limit": {
-								"title": "voltage_upper_limit",
-								"description": "Voltage upper limit, the threshold considered for determining overvoltages",
-								"units": "pu",
-								"type": "number"
-							},
-							"num_undervoltage_violation_buses": {
-								"title": "num_undervoltage_violation_buses",
-								"description": "Number of buses with voltage below voltage_lower_limit",
-								"type": "integer"
-							},
-							"voltage_lower_limit": {
-								"title": "voltage_lower_limit",
-								"description": "Voltage lower limit, the threshold considered for determining undervoltages",
-								"units": "pu",
-								"type": "number"
-							},
-							"max_line_loading": {
-								"title": "max_line_loading",
-								"description": "Maximum line loading",
-								"units": "pu",
-								"type": "number"
-							},
-							"max_transformer_loading": {
-								"title": "max_transformer_loading",
-								"description": "Maximum transformer loading",
-								"units": "pu",
-								"type": "number"
-							},
-							"num_line_violations": {
-								"title": "num_line_violations",
-								"description": "Number of lines with loading above line upper limit",
-								"type": "integer"
-							},
-							"line_upper_limit": {
-								"title": "line_upper_limit",
-								"description": "Line upper limit, the threshold considered for determining line overloading",
-								"units": "pu",
-								"type": "number"
-							},
-							"num_transformer_violations": {
-								"title": "num_transformer_violations",
-								"description": "Number of transformers with loading above transformer upper limit",
-								"type": "integer"
-							},
-							"transformer_upper_limit": {
-								"title": "transformer_upper_limit",
-								"description": "Transformer upper limit, the threshold considered for determining transformer overloading",
-								"units": "pu",
-								"type": "number"
-							}
-						},
-						"required": [
-							"name",
-							"stage",
-							"upgrade_type",
-							"simulation_time_s",
-							"thermal_violations_present",
-							"voltage_violations_present",
-							"max_bus_voltage",
-							"min_bus_voltage",
-							"num_voltage_violation_buses",
-							"num_overvoltage_violation_buses",
-							"voltage_upper_limit",
-							"num_undervoltage_violation_buses",
-							"voltage_lower_limit",
-							"max_line_loading",
-							"max_transformer_loading",
-							"num_line_violations",
-							"line_upper_limit",
-							"num_transformer_violations",
-							"transformer_upper_limit"
-						],
-						"additionalProperties": false
-					},
-					"TotalUpgradeCostsResultModel": {
-						"title": "UpgradeParamsBaseModel",
-						"description": "Provides total output costs for upgrading a type of equipment.",
-						"type": "object",
-						"properties": {
-							"name": {
-								"title": "name",
-								"description": "Job name",
-								"type": "string"
-							},
-							"type": {
-								"title": "type",
-								"description": "Equipment type",
-								"type": "string"
-							},
-							"count": {
-								"title": "count",
-								"description": "Count of upgraded equipment",
-								"type": "integer"
-							},
-							"total_cost_usd": {
-								"title": "total_cost_usd",
-								"description": "Total cost in US dollars",
-								"units": "dollars",
-								"type": "number"
-							}
-						},
-						"required": [
-							"name",
-							"type",
-							"count",
-							"total_cost_usd"
-						],
-						"additionalProperties": false
-					}
-				}
-			}
-
-		},
-		"DistributedGeneration": {
-			"type": "object",
-			"properties": {
-				"reopt_assumptions_file_path": {
-					"description": "File path of REopt assumptions file used to generate results, if known",
-					"type": "string"
-				},
-				"annual_renewable_electricity_pct": {
-					"description": "Percentage of annual renewable electricity generation",
-					"type": "number"
-				},
-				"lcc_us_dollars": {
-					"description": "Optimal lifecycle cost",
-					"type": "number"
-				},
-				"npv_us_dollars": {
-					"description": "Net present value of savings realized by the project",
-					"type": "number"
-				},
-				"year_one_energy_cost_us_dollars": {
-					"description": "Optimal year one utility energy cost",
-					"type": "number"
-				},
-				"year_one_demand_cost_us_dollars": {
-					"description": "Optimal year one utility demand cost",
-					"type": "number"
-				},
-				"year_one_bill_us_dollars": {
-					"description": "Optimal year one utility bill",
-					"type": "number"
-				},
-				"total_energy_cost_us_dollars": {
-					"description": "Total utility energy cost over the lifecycle, after-tax",
-					"type": "number"
-				},
-				"SolarPV": {
-					"$ref": "#/definitions/SolarPV"
-				},
-				"Wind": {
-					"$ref": "#/definitions/Wind"
-				},
-				"Generator": {
-					"$ref": "#/definitions/Generator"
-				},
-				"Storage": {
-					"$ref": "#/definitions/Storage"
-				}
-			}
-		},
-		"SolarPV": {
-			"type": "object",
-			"properties": {
-				"size_kw": {
-					"description": "rated power in kW",
-					"type": "number"
-				},
-				"location": {
-					"description": "Location of PV. Available options are roof, ground or both.",
-					"type": "string",
-					"enum": [
-						"roof",
-						"ground",
-						"both"
-					]
-				},
-				"tilt": {
-					"description": "PV system tilt",
-					"type": "number"
-				},
-				"azimuth": {
-					"description": "PV azimuth angle",
-					"type": "number"
-				}
-			}
-		},
-		"Wind": {
-			"type": "object",
-			"properties": {
-				"size_kw": {
-					"description": "rated power in kW",
-					"type": "number"
-				},
-				"average_yearly_energy_produced_kwh": {
-					"description": "average yearly energy produced in kWh",
-					"type": "number"
-				},
-				"size_class": {
-					"description": "Turbine size-class. One of [residential, commercial, medium, large]",
-					"type": "string"
-				}
-			}
-		},
-		"Generator": {
-			"type": "object",
-			"properties": {
-				"size_kw": {
-					"description": "rated power in kW",
-					"type": "number"
-				}
-			}
-		},
-		"Storage": {
-			"type": "object",
-			"properties": {
-				"size_kw": {
-					"description": "rated power in kW",
-					"type": "number"
-				},
-				"size_kwh": {
-					"description": "rated capacity in kWh",
-					"type": "number"
-				}
-			}
-		},
-		"RnmResults": {
-			"type": "object",
-			"properties": {
-				"demand_generation_planning": {
-					"description": "Demand generation planning",
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/DemandGenPlanning"
-					}
-				},
-				"electrical_lines_length": {
-					"$ref": "#/definitions/LineLength"
-				},
-				"distribution_transformers_capacity_kva": {
-					"description": "Distribution transformers capacity in kVA",
-					"type": "number"
-				},
-				"costs": {
-					"description": "Costs",
-					"type": "object",
-					"properties": {
-						"investment": {
-							"$ref": "#/definitions/RnmCost"
-						},
-						"yearly_maintenance": {
-							"$ref": "#/definitions/RnmCost"
-						}
-					}
-				},
-				"reliability_indexes": {
-					"description": "Reliability Indexes",
-					"type": "object",
-					"properties": {
-						"SAIDI": {
-							"description": "System Average Interruption Duration Index",
-							"type": "number"
-						},
-						"SAIFI": {
-							"description": "System Average Interruption Frequency Index",
-							"type": "number"
-						}
-					}
-				}
-			}
-		},
-		"DemandGenPlanning": {
-			"type": "object",
-			"properties": {
-				"type": {
-					"description": "Type of demand generation planning",
-					"type": "string",
-					"enum": [
-						"Low Voltage (LV) Consumers",
-						"Medium Voltage (MV) Consumers",
-						"Low Voltage (LV) Distributed generators",
-						"Medium Voltage (MV) Distributed generators"
-					]
-				},
-				"peak_demand_kw": {
-					"description": "Peak demand in kw for this type",
-					"type": "number"
-				},
-				"number_of_nodes_in_network": {
-					"description": "Number of nodes of this type in the network",
-					"type": "number"
-				}
-			}
-		},
-		"LineLength": {
-			"overhead_mi": {
-				"description": "Length of overhead lines (miles)",
-				"type": "number"
-			},
-			"underground_mi": {
-				"description": "Length of underground lines (miles)",
-				"type": "number"
-			},
-			"type": "object",
-			"properties": {
-				"overhead_mi": {
-					"description": "Length of overhead lines (miles)",
-					"type": "number"
-				},
-				"underground_mi": {
-					"description": "Length of underground lines (miles)",
-					"type": "number"
-				}
-			}
-		},
-		"RnmCost": {
-			"low_voltage_network": {
-				"description": "Low Voltage Network Cost ($)",
-				"type": "number"
-			},
-			"distribution_transformers": {
-				"description": "Distribution Transformers Cost ($)",
-				"type": "number"
-			},
-			"medium_voltage_network": {
-				"description": "Medium Voltage Network Cost ($)",
-				"type": "number"
-			},
-			"primary_substations": {
-				"description": "Primary Substations Cost ($)",
-				"type": "number"
-			},
-			"total": {
-				"description": "Total Cost ($)",
-				"type": "number"
-			},
-			"type": "object",
-			"properties": {
-				"low_voltage_network": {
-					"description": "Low Voltage Network Cost ($)",
-					"type": "number"
-				},
-				"distribution_transformers": {
-					"description": "Distribution Transformers Cost ($)",
-					"type": "number"
-				},
-				"medium_voltage_network": {
-					"description": "Medium Voltage Network Cost ($)",
-					"type": "number"
-				},
-				"primary_substations": {
-					"description": "Primary Substations Cost ($)",
-					"type": "number"
-				},
-				"total": {
-					"description": "TOtal Cost ($)",
-					"type": "number"
-				}
-			}
-		},
-		"qaqc_flags": {
-			"type": "object",
-			"properties": {
-				"eui_reasonableness": {
-					"description": "Whether the EUI is within ASHRAE 90.1-2013 bounds for that building type",
-					"type": ["integer", "null"]
-				},
-				"end_use_by_category": {
-					"description": "Whether building energy use is within ASHRAE 90.1-2013 bounds for that building type",
-					"type": ["integer", "null"]
-				},
-				"mechanical_system_part_load_efficiency": {
-					"description": "Whether 40% & 80% heating and cooling efficiency is within ASHRAE 90.1-2013 bounds for that building type",
-					"type": ["integer", "null"]
-				},
-				"simultaneous_heating_and_cooling": {
-					"description": "Whether heating and cooling are occuring during the same hour when cooling load exists",
-					"type": ["integer", "null"]
-				},
-				"internal_loads": {
-					"description": "Whether lighting, plug, and equipment use is within ASHRAE 90.1-2013 bounds for that building type",
-					"type": ["integer", "null"]
-				},
-				"schedules": {
-					"description": "Whether lighting, ventilation, occupant, plug, and equipment schedules are within ASHRAE 90.1-2013 bounds for that building type",
-					"type": ["integer", "null"]
-				},
-				"envelope_r_value": {
-					"description": "Whether building envelope is within ASHRAE 90.1-2013 bounds for that building type",
-					"type": ["integer", "null"]
-				},
-				"domestic_hot_water": {
-					"description": "Whether DHW energy use is within 2011 ASHRAE handbook bounds for that building type",
-					"type": ["integer", "null"]
-				},
-				"mechanical_system_efficiency": {
-					"description": "Whether heating and cooling efficiency is within ASHRAE 90.1-2013 bounds for that building type",
-					"type": ["integer", "null"]
-				},
-				"supply_and_zone_air_temperature": {
-					"description": "Whether fan effectiveness is within ASHRAE 90.1-2013 bounds for that building type",
-					"type": ["integer", "null"]
-				},
-				"total_qaqc_flags": {
-					"description": "How many QAQC flags have been raised for this feature or scenario",
-					"type": ["integer", "null"]
-				}
-			}
-		},
-		"FeatureReport": {
-			"type": "object",
-			"properties": {
-				"id": {
-					"description": "Id refers to the id of a building/feature",
-					"type": "string"
-				},
-				"name": {
-					"description": "name refers to the name of the feature (eg. Building 1, tranformer 5)",
-					"type": "string"
-				},
-				"directory_name": {
-					"type": "string"
-				},
-				"feature_type": {
-					"type": "string",
-					"enum": [
-						"Building",
-						"District System",
-						"Transformer"
-					]
-				},
-				"timesteps_per_hour": {
-					"$ref": "#/definitions/TimestepsPerHour"
-				},
-				"simulation_status": {
-					"type": "string",
-					"enum": [
-						"Not Started",
-						"Started",
-						"Complete",
-						"Failed"
-					]
-				},
-				"timeseries_csv": {
-					"$ref": "#/definitions/TimeseriesCSV"
-				},
-				"location": {
-					"$ref": "#/definitions/Location"
-				},
-				"program": {
-					"$ref": "#/definitions/Program"
-				},
-				"design_parameters": {
-					"$ref": "#/definitions/DesignParameters"
-				},
-				"construction_costs": {
-					"$ref": "#/definitions/ConstructionCosts"
-				},
-				"reporting_periods": {
-					"$ref": "#/definitions/ReportingPeriods"
-				},
-				"distributed_generation": {
-					"$ref": "#/definitions/DistributedGeneration"
-				},
-				"power_distribution": {
-					"$ref": "#/definitions/PowerDistribution"
-				},
-				"thermal_storage": {
-					"$ref": "#/definitions/ThermalStorage"
-				},
-				"qaqc_flags": {
-					"$ref": "#/definitions/qaqc_flags"
-				}
-			},
-			"required": [
-				"id",
-				"name",
-				"directory_name",
-				"feature_type",
-				"timesteps_per_hour",
-				"simulation_status"
-			],
-			"additionalProperties": false
-		},
-		"ReportingPeriods": {
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/ReportingPeriod"
-			}
-		},
-		"ReportingPeriod": {
-			"description": "Non-overlapping reporting periods",
-			"type": "object",
-			"properties": {
-				"id": {
-					"description": "Id refers to the id of the reporting period. Ids of reporting periods are matched across simulations, so the same period of time gets the same id for all simulations.",
-					"type": "number"
-				},
-				"name": {
-					"description": "name refers to the name of the reporting period(eg. Annual, January)",
-					"type": "string"
-				},
-				"multiplier": {
-					"description": "Multiplier used if this reporting period is representative of mulitple periods.  For example one week simulation that represents entire month.",
-					"type": "number",
-					"default": 1
-				},
-				"start_date": {
-					"$ref": "#/definitions/Date"
-				},
-				"end_date": {
-					"$ref": "#/definitions/Date"
-				},
-				"total_site_energy_kwh": {
-					"description": "Total energy used on site, does not include generation (kWh)",
-					"type": "number"
-				},
-				"total_source_energy_kwh": {
-					"description": "Total source energy used, does not include generation (kWh)",
-					"type": "number"
-				},
-				"site_EUI_kwh_per_m2": {
-					"type": "number"
-				},
-				"site_EUI_kBtu_per_ft2": {
-					"type": "number"
-				},
-				"source_EUI_kwh_per_m2": {
-					"type": "number"
-				},
-				"source_EUI_kBtu_per_ft2": {
-					"type": "number"
-				},
-				"net_site_energy_kwh": {
-					"description": "Net site energy (kWh)",
-					"type": "number"
-				},
-				"net_source_energy_kwh": {
-					"description": "Net source energy (kWh)",
-					"type": "number"
-				},
-				"total_utility_cost_dollar": {
-					"description": "Total utility cost ($)",
-					"type": "number"
-				},
-				"net_utility_cost_dollar": {
-					"description": "Net utility cost for reporting period includes generation ($)",
-					"type": "number"
-				},
-				"utility_costs_dollar": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/UtilityCost"
-					}
-				},
-				"electricity_kwh": {
-					"description": "Sum of all electricity used, does not include electricity produced (kWh)",
-					"type": "number"
-				},
-				"natural_gas_kwh": {
-					"description": "Sum of all natural gas end uses consumption (kWh)",
-					"type": "number"
-				},
-				"propane_kwh": {
-					"description": "Sum of all propane end uses consumption (kWh)",
-					"type": "number"
-				},
-				"fuel_oil_kwh": {
-					"description": "Sum of all fuel oil #2 end uses consumption (kWh)",
-					"type": "number"
-				},
-				"other_fuels_kwh": {
-					"description": "Sum of all other (fuel oil #1, diesel, gasoline, coal, steam) fuel end uses consumption (kWh)",
-					"type": "number"
-				},
-				"district_cooling_kwh": {
-					"description": "Sum of all distric cooling end uses consumption (kWh)",
-					"type": "number"
-				},
-				"district_heating_kwh": {
-					"description": "Sum of all distric heating end uses consumption (kWh)",
-					"type": "number"
-				},
-				"water_qbft": {
-					"description": "Sum of all water end uses consumption (ft^3)",
-					"type": "number"
-				},
-				"electricity_produced_kwh": {
-					"description": "Sum of all electricity produced (kWh)",
-					"type": "number"
-				},
-				"end_uses": {
-					"$ref": "#/definitions/EndUses"
-				},
-				"energy_production_kwh": {
-					"description": "Energy produced for reporting period.  Water reported in m^3, all others in kWh.",
-					"type": "object",
-					"properties": {
-						"electricity_produced": {
-							"type": "object",
-							"properties": {
-								"photovoltaic": {
-									"type": "number"
-								}
-							},
-							"additionalProperties": false
-						}
-					},
-					"additionalProperties": false
-				},
-				"comfort_result": {
-					"$ref": "#/definitions/ComfortResult"
-				},
-				"emissions": {
-					"type": "object",
-					"properties": {
-						"future_annual_electricity_emissions_mt": {
-							"description": "Future emissions in metric ton (mt) calculated based on an annual emission factor value for the selected future year",
-							"type": "number"
-						},
-						"future_hourly_electricity_emissions_mt": {
-							"description": "Future emissions in metric ton (mt) calculated based on hourly emission factor values for the selected future year",
-							"type": "number"
-						},
-						"historical_annual_electricity_emissions_mt": {
-							"description": "Historical emissions in metric ton (mt) calculated based on an annual emission factor value for the selected historical year",
-							"type": "number"
-						},
-						"historical_hourly_electricity_emissions_mt": {
-							"description": "Historical emissions in metric ton (mt) calculated based on hourly emission factor values for the selected historical year",
-							"type": "number"
-						},
-						"future_annual_electricity_emissions_intensity_kg_per_ft2": {
-							"description": "Future emissions intensity in kg/ft2 calculated based on an annual emission factor value for the selected future year",
-							"type": "number"
-						},
-						"future_hourly_electricity_emissions_intensity_kg_per_ft2": {
-							"description": "Future emissions intensity in kg/ft2 calculated based on hourly emission factor values for the selected future year",
-							"type": "number"
-						},
-						"historical_annual_electricity_emissions_intensity_kg_per_ft2": {
-							"description": "Historical emissions intensity in kg/ft2 calculated based on an annual emission factor value for the selected historical year",
-							"type": "number"
-						},
-						"historical_hourly_electricity_emissions_intensity_kg_per_ft2": {
-							"description": "Historical emissions intensity in kg/ft2 calculated based on hourly emission factor values for the selected historical year",
-							"type": "number"
-						},
-						"natural_gas_emissions_mt": {
-							"description": "Natural Gas emissions in mt calculated based on EPA eGRID data and calculated using 20-year GWP horizon based on ASHRAE 189.1",
-							"type": "number"
-						},
-						"natural_gas_emissions_intensity_kg_per_ft2": {
-							"description": "Natural Gas emissions intensity in kg/ft2 calculated based on EPA eGRID data and calculated using 20-year GWP horizon based on ASHRAE 189.1",
-							"type": "number"
-						},
-						"propane_emissions_mt": {
-							"description": "Propane emissions in mt calculated based on EPA eGRID data and calculated using 20-year GWP horizon based on ASHRAE 189.1",
-							"type": "number"
-						},
-						"propane_emissions_intensity_kg_per_ft2": {
-							"description": "Propane emissions intensity in kg/ft2 calculated based on EPA eGRID data and calculated using 20-year GWP horizon based on ASHRAE 189.1",
-							"type": "number"
-						},
-						"fueloil_no2_emissions_mt": {
-							"description": "FuelOilNo2 emissions in mt calculated based on EPA eGRID data and calculated using 20-year GWP horizon based on ASHRAE 189.1",
-							"type": "number"
-						},
-						"fueloil_no2_emissions_intensity_kg_per_ft2": {
-							"description": "FuelOilNo2 emissions intensity in kg/ft2 calculated based on EPA eGRID data and calculated using 20-year GWP horizon based on ASHRAE 189.1",
-							"type": "number"
-						}
-					}
-				}
-			},
-			"additionalProperties": false
-		},
-		"Date": {
-			"type": "object",
-			"properties": {
-				"month": {
-					"type": "integer"
-				},
-				"day_of_month": {
-					"type": "integer"
-				},
-				"year": {
-					"type": "integer"
-				}
-			},
-			"additionalProperties": false
-		},
-		"EndUses": {
-			"description": "End uses for reporting period.  Does not include energy produced. Water reported in m^3, all others in kWh.",
-			"type": "object",
-			"properties": {
-				"electricity_kwh": {
-					"$ref": "#/definitions/EndUse"
-				},
-				"natural_gas_kwh": {
-					"$ref": "#/definitions/EndUse"
-				},
-				"propane_kwh": {
-					"$ref": "#/definitions/EndUse"
-				},
-				"fuel_oil_kwh": {
-					"$ref": "#/definitions/EndUse"
-				},
-				"other_fuels_kwh": {
-					"$ref": "#/definitions/EndUse"
-				},
-				"district_cooling_kwh": {
-					"$ref": "#/definitions/EndUse"
-				},
-				"district_heating_kwh": {
-					"$ref": "#/definitions/EndUse"
-				},
-				"water_qbft": {
-					"$ref": "#/definitions/EndUse"
-				}
-			},
-			"additionalProperties": false
-		},
-		"EndUse": {
-			"type": "object",
-			"properties": {
-				"heating": {
-					"type": "number"
-				},
-				"cooling": {
-					"type": "number"
-				},
-				"interior_lighting": {
-					"type": "number"
-				},
-				"exterior_lighting": {
-					"type": "number"
-				},
-				"interior_equipment": {
-					"type": "number"
-				},
-				"exterior_equipment": {
-					"type": "number"
-				},
-				"electric_vehicles": {
-					"type": "number"
-				},
-				"fans": {
-					"type": "number"
-				},
-				"pumps": {
-					"type": "number"
-				},
-				"heat_rejection": {
-					"type": "number"
-				},
-				"humidification": {
-					"type": "number"
-				},
-				"heat_recovery": {
-					"type": "number"
-				},
-				"water_systems": {
-					"type": "number"
-				},
-				"refrigeration": {
-					"type": "number"
-				},
-				"generators": {
-					"type": "number"
-				}
-			},
-			"additionalProperties": false
-		},
-		"ComfortResult": {
-			"type": "object",
-			"properties": {
-				"time_setpoint_not_met_during_occupied_cooling": {
-					"description": "(hrs)",
-					"type": "number"
-				},
-				"time_setpoint_not_met_during_occupied_heating": {
-					"description": "(hrs)",
-					"type": "number"
-				},
-				"time_setpoint_not_met_during_occupied_hours": {
-					"description": "(hrs)",
-					"type": "number"
-				},
-				"hours_out_of_comfort_bounds_PMV": {
-					"type": "number"
-				},
-				"hours_out_of_comfort_bounds_PPD": {
-					"type": "number"
-				}
-			},
-			"additionalProperties": false
-		},
-		"ConstructionCosts": {
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/ConstructionCost"
-			}
-		},
-		"ConstructionCost": {
-			"description": "Program related information, does not change in time",
-			"type": "object",
-			"properties": {
-				"category": {
-					"type": "string",
-					"enum": [
-						"Construction",
-						"Building",
-						"Space",
-						"ThermalZone",
-						"AirLoop",
-						"PlantLoop",
-						"ZoneHVAC",
-						"Lights",
-						"Luminaire",
-						"Equipment",
-						"HVACComponent",
-						"ZoneHVACComponent"
-					]
-				},
-				"item_name": {
-					"description": "Name of the item being costed, e.g. the name of the exterior wall construction",
-					"type": "string"
-				},
-				"unit_cost": {
-					"description": "Cost per unit of item, e.g. cost per area of construction.  This can be adjusted in post processing.",
-					"type": "number"
-				},
-				"cost_units": {
-					"description": "Unit of cost for this item",
-					"type": "string",
-					"enum": [
-						"CostPerEach",
-						"CostPerFt2",
-						"CostPerKW",
-						"CostPerCFM"
-					]
-				},
-				"item_quantity": {
-					"description": "Amount of the item in units corresponding to cost_units",
-					"type": "number"
-				},
-				"total_cost": {
-					"description": "Total cost is unit_cost multiplied by item_quantity. Can be updated if unit_cost is changed.",
-					"type": "number"
-				}
-			},
-			"additionalProperties": false
-		},
-		"UtilityCost": {
-			"type": "object",
-			"properties": {
-				"fuel_type": {
-					"type": "string",
-					"enum": [
-						"Electricity",
-						"Natural Gas",
-						"Propane",
-						"Fuel Oil",
-						"District Cooling",
-						"District Heating",
-						"Other Fuels",
-						"Water"
-					]
-				},
-				"total_cost": {
-					"description": "($)",
-					"type": "number"
-				},
-				"usage_cost": {
-					"description": "($)",
-					"type": "number"
-				},
-				"demand_cost": {
-					"description": "($)",
-					"type": "number"
-				}
-			},
-			"additionalProperties": false
-		},
-		"Location": {
-			"type": "object",
-			"properties": {
-				"latitude_deg": {
-					"description": "latitude for the centroid of the feature (deg)",
-					"type": "number"
-				},
-				"longitude_deg": {
-					"description": "longitude for the centroid of the feature (deg)",
-					"type": "number"
-				},
-				"surface_elevation_ft": {
-					"description": "The surface elevation (above NAVD88 datum) (ft).",
-					"type": "number"
-				},
-				"weather_filename": {
-					"description": "Name of EPW weather file.",
-					"type": "string"
-				}
-			},
-			"additionalProperties": false
-		},
-		"TimestepsPerHour": {
-			"type": "integer",
-			"minimum": 1,
-			"maximum": 60
-		},
-		"Program": {
-			"type": "object",
-			"properties": {
-				"site_area_sqft": {
-					"description": "Area of the entire site or lot (ft^2)",
-					"type": "number"
-				},
-				"floor_area_sqft": {
-					"description": "Building gross floor area (ft^2)",
-					"type": "number"
-				},
-				"conditioned_area_sqft": {
-					"description": "Building conditioned floor area (ft^2)",
-					"type": "number"
-				},
-				"unconditioned_area_sqft": {
-					"description": "Building unconditioned floor area (ft^2)",
-					"type": "number"
-				},
-				"footprint_area_sqft": {
-					"description": "Building floorprint area (ft^2)",
-					"type": "number"
-				},
-				"maximum_roof_height_ft": {
-					"description": "Maximum height of the roof relative to surface elevation (ft)",
-					"type": "number"
-				},
-				"maximum_number_of_stories": {
-					"description": "The maximum number of building stories, sum of number of above and below ground stories.",
-					"type": "number"
-				},
-				"maximum_number_of_stories_above_ground": {
-					"description": "The maximum number of building stories above ground",
-					"type": "number"
-				},
-				"parking_area_sqft": {
-					"description": "Parking gross area (ft^2)",
-					"type": "number"
-				},
-				"number_of_parking_spaces": {
-					"description": "Number of parking spaces",
-					"type": "number"
-				},
-				"number_of_parking_spaces_charging": {
-					"description": "Number of parking spaces with electric vehicle charging",
-					"type": "number"
-				},
-				"parking_footprint_area_sqft": {
-					"description": "Parking floorprint area (ft^2)",
-					"type": "number"
-				},
-				"maximum_parking_height_ft": {
-					"description": "Maximum height of the parking structure relative to surface elevation (ft)",
-					"type": "number"
-				},
-				"maximum_number_of_parking_stories": {
-					"description": "The maximum number of parking stories, sum of number of above and below ground stories.",
-					"type": "number"
-				},
-				"maximum_number_of_parking_stories_above_ground": {
-					"description": "The maximum number of parking stories above ground",
-					"type": "number"
-				},
-				"number_of_residential_units": {
-					"description": "Total number of residential units.",
-					"type": "integer"
-				},
-				"building_types": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/BuildingType"
-					}
-				},
-				"window_area_sqft": {
-					"description": "Exterior windows gross area (ft^2)",
-					"type": "object",
-					"properties": {
-						"north_window_area_sqft": {
-							"type": "number"
-						},
-						"south_window_area_sqft": {
-							"type": "number"
-						},
-						"east_window_area_sqft": {
-							"type": "number"
-						},
-						"west_window_area_sqft": {
-							"type": "number"
-						},
-						"total_window_area_sqft": {
-							"type": "number"
-						}
-					},
-					"required": [
-						"total_window_area_sqft"
-					],
-					"additionalProperties": false
-				},
-				"wall_area_sqft": {
-					"description": "exterior walls gross area (ft^2)",
-					"type": "object",
-					"properties": {
-						"north_wall_area_sqft": {
-							"type": "number"
-						},
-						"south_wall_area_sqft": {
-							"type": "number"
-						},
-						"east_wall_area_sqft": {
-							"type": "number"
-						},
-						"west_wall_area_sqft": {
-							"type": "number"
-						},
-						"total_wall_area_sqft": {
-							"type": "number"
-						}
-					},
-					"required": [
-						"north_wall_area_sqft",
-						"south_wall_area_sqft",
-						"east_wall_area_sqft",
-						"west_wall_area_sqft",
-						"total_wall_area_sqft"
-					],
-					"additionalProperties": false
-				},
-				"roof_area_sqft": {
-					"type": "object",
-					"properties": {
-						"equipment_roof_area_sqft": {
-							"type": "number"
-						},
-						"photovoltaic_roof_area_sqft": {
-							"type": "number"
-						},
-						"available_roof_area_sqft": {
-							"description": "gross roof area (ft^2)",
-							"type": "number"
-						},
-						"total_roof_area_sqft": {
-							"description": "Exterior roofs gross area (ft^2)",
-							"type": "number"
-						}
-					},
-					"required": [
-						"total_roof_area_sqft"
-					],
-					"additionalProperties": false
-				},
-				"orientation_deg": {
-					"description": "Rotation of longest axis from East-West,about up axis (deg)",
-					"type": "number"
-				},
-				"aspect_ratio": {
-					"description": "Ratio of longest to shortest axis",
-					"type": "number"
-				},
-				"total_construction_cost_dollar": {
-					"description": "total construction cost calculated from the defined cost per floor area ($)",
-					"type": "number"
-				}
-			},
-			"required": [
-				"floor_area_sqft",
-				"conditioned_area_sqft",
-				"unconditioned_area_sqft",
-				"footprint_area_sqft",
-				"maximum_roof_height_ft",
-				"number_of_residential_units",
-				"building_types",
-				"window_area_sqft",
-				"wall_area_sqft",
-				"roof_area_sqft"
-			],
-			"additionalProperties": false
-		},
-		"BuildingType": {
-			"type": "object",
-			"properties": {
-				"building_type": {
-					"description": "Primary building space type",
-					"type": "string",
-					"enum": [
-						"Single-Family",
-						"Multifamily (2 to 4 units)",
-						"Multifamily (5 or more units)",
-						"Mobile Home",
-						"Vacant",
-						"Office",
-						"Laboratory",
-						"Nonrefrigerated warehouse",
-						"Food sales",
-						"Public order and safety",
-						"Outpatient health care",
-						"Refrigerated warehouse",
-						"Religious worship",
-						"Public assembly",
-						"Education",
-						"Food service",
-						"Inpatient health care",
-						"Nursing",
-						"Lodging",
-						"Strip shopping mall",
-						"Enclosed mall",
-						"Retail other than mall",
-						"Service"
-					]
-				},
-				"maximum_occupancy": {
-					"description": "Maximum number of occupants ",
-					"type": "number"
-				},
-				"floor_area": {
-					"description": "Building gross floor area of this type (ft^2)",
-					"type": "number"
-				}
-			},
-			"required": [
-				"building_type",
-				"maximum_occupancy",
-				"floor_area"
-			],
-			"additionalProperties": false
-		},
-		"DesignParameters": {
-			"type": "object",
-			"properties": {
-				"district_cooling_chilled_water_rate": {
-					"type": "number"
-				},
-				"district_cooling_mass_flow_rate": {
-					"type": "number"
-				},
-				"district_cooling_inlet_temperature": {
-					"type": "number"
-				},
-				"district_cooling_outlet_temperature": {
-					"type": "number"
-				},
-				"district_heating_hot_water_rate": {
-					"type": "number"
-				},
-				"district_heating_mass_flow_rate": {
-					"type": "number"
-				},
-				"district_heating_inlet_temperature": {
-					"type": "number"
-				},
-				"district_heating_outlet_temperature": {
-					"type": "number"
-				}
-			},
-			"additionalProperties": false
-		},
-		"TimeseriesCSV": {
-			"type": "object",
-			"properties": {
-				"path": {
-					"type": "string"
-				},
-				"first_report_datetime": {
-					"type": "string"
-				},
-				"column_names": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			},
-			"required": [
-				"path",
-				"first_report_datetime",
-				"column_names"
-			],
-			"additionalProperties": false
-		},
-		"PowerDistribution": {
-			"type": "object",
-			"properties": {
-				"over_voltage_hours": {
-					"type": "number"
-				},
-				"under_voltage_hours": {
-					"type": "number"
-				}
-			}
-		},
-		"ThermalStorage": {
-			"type": "object",
-			"properties": {
-				"its_size": {
-					"description": "Total central plant TES capacity in kWh",
-					"type": "number"
-				},
-				"ptes_size": {
-					"description": "Total distributed/packaged TES capacity in kWh",
-					"type": "number"
-				}
-			}
-		}
-	}
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Comment describing your JSON Schema",
+  "type": "object",
+  "properties": {
+    "scenario_report": {
+      "$ref": "#/definitions/ScenarioReport"
+    },
+    "feature_reports": {
+      "description": "features of each data point in the scenario",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/FeatureReport"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "ScenarioReport": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "directory_name": {
+          "type": "string"
+        },
+        "timesteps_per_hour": {
+          "$ref": "#/definitions/TimestepsPerHour"
+        },
+        "number_of_not_started_simulations": {
+          "type": "number"
+        },
+        "number_of_started_simulations": {
+          "type": "number"
+        },
+        "number_of_complete_simulations": {
+          "type": "number"
+        },
+        "number_of_failed_simulations": {
+          "type": "number"
+        },
+        "location": {
+          "$ref": "#/definitions/Location"
+        },
+        "timeseries_csv": {
+          "$ref": "#/definitions/TimeseriesCSV"
+        },
+        "program": {
+          "$ref": "#/definitions/Program"
+        },
+        "construction_costs": {
+          "$ref": "#/definitions/ConstructionCosts"
+        },
+        "reporting_periods": {
+          "$ref": "#/definitions/ReportingPeriods"
+        },
+        "distributed_generation": {
+          "$ref": "#/definitions/DistributedGeneration"
+        },
+        "thermal_storage": {
+          "$ref": "#/definitions/ThermalStorage"
+        },
+        "rnm_results": {
+          "$ref": "#/definitions/RnmResults"
+        },
+        "scenario_power_distribution": {
+          "$ref": "#/definitions/ScenarioPowerDistribution"
+        },
+        "scenario_power_distribution_cost": {
+          "$ref": "#/definitions/ScenarioPowerDistributionCost"
+        },
+        "qaqc_flags": {
+          "$ref": "#/definitions/qaqc_flags"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "directory_name",
+        "timesteps_per_hour",
+        "number_of_not_started_simulations",
+        "number_of_started_simulations",
+        "number_of_complete_simulations",
+        "number_of_failed_simulations",
+        "program"
+      ],
+      "additionalProperties": false
+    },
+    "ScenarioPowerDistribution": {
+      "type": "object",
+      "properties": {
+        "substations": {
+          "description": "Array of electrical substations",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "nominal_voltage": {
+                "description": "Nominal Voltage (V)",
+                "type": "number"
+              }
+            }
+          }
+        },
+        "distribution_lines": {
+          "description": "Array of distribution lines",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "length": {
+                "description": "Length of the line (m)",
+                "type": "number"
+              },
+              "ampacity": {
+                "description": "Maximum ampacity of the line (A)",
+                "type": "number"
+              },
+              "commercial_line_type": {
+                "description": "Array of the wire types that make up the line",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "ScenarioPowerDistributionCost": {
+      "title": "UpgradeParamsBaseModel",
+      "description": "Contains results from all jobs in the simulation.",
+      "type": "object",
+      "properties": {
+        "results": {
+          "title": "results",
+          "description": "Results summary for each job",
+          "type": "array",
+          "items": {}
+        },
+        "outputs": {
+          "title": "outputs",
+          "description": "Outputs for each job in the simulation.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ScenarioPowerDistributionCost/definitions/UpgradeSimulationOutputModel"
+            }
+          ]
+        },
+        "violation_summary": {
+          "title": "upgrade_summary",
+          "description": "Contains thermal or voltage upgrade results for each job",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ScenarioPowerDistributionCost/definitions/UpgradeViolationResultModel"
+          }
+        },
+        "costs_per_equipment": {
+          "title": "costs_per_equipment",
+          "description": "Contains upgrade cost information for each job by equipment type",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ScenarioPowerDistributionCost/definitions/TotalUpgradeCostsResultModel"
+          }
+        },
+        "equipment": {
+          "title": "equipment",
+          "description": "Contains equipment information for each job",
+          "type": "array",
+          "items": {}
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "UpgradeJobOutputModel": {
+          "title": "UpgradeParamsBaseModel",
+          "description": "Contains outputs from one job.",
+          "type": "object",
+          "properties": {
+            "upgraded_opendss_model_file": {
+              "title": "upgraded_opendss_model_file",
+              "description": "Path to file that will load the upgraded network.",
+              "type": "string"
+            },
+            "feeder_stats": {
+              "title": "feeder_stats",
+              "description": "Path to file containing feeder metadata and equipment details before and after upgrades.",
+              "type": "string"
+            },
+            "return_code": {
+              "title": "return_code",
+              "description": "Return code from process. Zero is success, non-zero is a failure.",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "upgraded_opendss_model_file",
+            "feeder_stats",
+            "return_code"
+          ],
+          "additionalProperties": false
+        },
+        "UpgradeSimulationOutputModel": {
+          "title": "UpgradeParamsBaseModel",
+          "description": "Contains outputs from all jobs in the simulation.",
+          "type": "object",
+          "properties": {
+            "log_file": {
+              "title": "log_file",
+              "description": "Path to log file for the simulation.",
+              "type": "string"
+            },
+            "jobs": {
+              "title": "jobs",
+              "description": "Outputs for each job in the simulation.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ScenarioPowerDistributionCost/definitions/UpgradeJobOutputModel"
+              }
+            }
+          },
+          "required": [
+            "log_file",
+            "jobs"
+          ],
+          "additionalProperties": false
+        },
+        "UpgradeViolationResultModel": {
+          "title": "UpgradeParamsBaseModel",
+          "description": "Defines result parameters for thermal upgrades.",
+          "type": "object",
+          "properties": {
+            "name": {
+              "title": "name",
+              "description": "Job name that produced the result",
+              "type": "string"
+            },
+            "scenario": {
+              "title": "scenario",
+              "description": "Simulation scenario describing the controls being used",
+              "default": "control_mode",
+              "type": "string"
+            },
+            "stage": {
+              "title": "stage",
+              "description": "Stage of upgrades: initial (before upgrades) or final (after upgrades)",
+              "type": "string"
+            },
+            "upgrade_type": {
+              "title": "upgrade_type",
+              "description": "Type of upgrade: thermal or voltage",
+              "type": "string"
+            },
+            "simulation_time_s": {
+              "title": "simulation_time_s",
+              "description": "Simulation time to perform upgrades (seconds)",
+              "type": "number"
+            },
+            "thermal_violations_present": {
+              "title": "thermal_violations_present",
+              "description": "Flag indicating whether thermal violations are present",
+              "type": "boolean"
+            },
+            "voltage_violations_present": {
+              "title": "voltage_violations_present",
+              "description": "Flag indicating whether voltage violations are present",
+              "type": "boolean"
+            },
+            "max_bus_voltage": {
+              "title": "max_bus_voltage",
+              "description": "Maximum voltage recorded on any bus",
+              "units": "pu",
+              "type": "number"
+            },
+            "min_bus_voltage": {
+              "title": "min_bus_voltage",
+              "description": "Minimum voltage recorded on any bus",
+              "units": "pu",
+              "type": "number"
+            },
+            "num_voltage_violation_buses": {
+              "title": "num_voltage_violation_buses",
+              "description": "Number of buses with voltage violations",
+              "type": "integer"
+            },
+            "num_overvoltage_violation_buses": {
+              "title": "num_overvoltage_violation_buses",
+              "description": "Number of buses with voltage above voltage_upper_limit",
+              "type": "integer"
+            },
+            "voltage_upper_limit": {
+              "title": "voltage_upper_limit",
+              "description": "Voltage upper limit, the threshold considered for determining overvoltages",
+              "units": "pu",
+              "type": "number"
+            },
+            "num_undervoltage_violation_buses": {
+              "title": "num_undervoltage_violation_buses",
+              "description": "Number of buses with voltage below voltage_lower_limit",
+              "type": "integer"
+            },
+            "voltage_lower_limit": {
+              "title": "voltage_lower_limit",
+              "description": "Voltage lower limit, the threshold considered for determining undervoltages",
+              "units": "pu",
+              "type": "number"
+            },
+            "max_line_loading": {
+              "title": "max_line_loading",
+              "description": "Maximum line loading",
+              "units": "pu",
+              "type": "number"
+            },
+            "max_transformer_loading": {
+              "title": "max_transformer_loading",
+              "description": "Maximum transformer loading",
+              "units": "pu",
+              "type": "number"
+            },
+            "num_line_violations": {
+              "title": "num_line_violations",
+              "description": "Number of lines with loading above line upper limit",
+              "type": "integer"
+            },
+            "line_upper_limit": {
+              "title": "line_upper_limit",
+              "description": "Line upper limit, the threshold considered for determining line overloading",
+              "units": "pu",
+              "type": "number"
+            },
+            "num_transformer_violations": {
+              "title": "num_transformer_violations",
+              "description": "Number of transformers with loading above transformer upper limit",
+              "type": "integer"
+            },
+            "transformer_upper_limit": {
+              "title": "transformer_upper_limit",
+              "description": "Transformer upper limit, the threshold considered for determining transformer overloading",
+              "units": "pu",
+              "type": "number"
+            }
+          },
+          "required": [
+            "name",
+            "stage",
+            "upgrade_type",
+            "simulation_time_s",
+            "thermal_violations_present",
+            "voltage_violations_present",
+            "max_bus_voltage",
+            "min_bus_voltage",
+            "num_voltage_violation_buses",
+            "num_overvoltage_violation_buses",
+            "voltage_upper_limit",
+            "num_undervoltage_violation_buses",
+            "voltage_lower_limit",
+            "max_line_loading",
+            "max_transformer_loading",
+            "num_line_violations",
+            "line_upper_limit",
+            "num_transformer_violations",
+            "transformer_upper_limit"
+          ],
+          "additionalProperties": false
+        },
+        "TotalUpgradeCostsResultModel": {
+          "title": "UpgradeParamsBaseModel",
+          "description": "Provides total output costs for upgrading a type of equipment.",
+          "type": "object",
+          "properties": {
+            "name": {
+              "title": "name",
+              "description": "Job name",
+              "type": "string"
+            },
+            "type": {
+              "title": "type",
+              "description": "Equipment type",
+              "type": "string"
+            },
+            "count": {
+              "title": "count",
+              "description": "Count of upgraded equipment",
+              "type": "integer"
+            },
+            "total_cost_usd": {
+              "title": "total_cost_usd",
+              "description": "Total cost in US dollars",
+              "units": "dollars",
+              "type": "number"
+            }
+          },
+          "required": [
+            "name",
+            "type",
+            "count",
+            "total_cost_usd"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "DistributedGeneration": {
+      "type": "object",
+      "properties": {
+        "reopt_assumptions_file_path": {
+          "description": "File path of REopt assumptions file used to generate results, if known",
+          "type": "string"
+        },
+        "annual_renewable_electricity_pct": {
+          "description": "Percentage of annual renewable electricity generation",
+          "type": "number"
+        },
+        "lcc_us_dollars": {
+          "description": "Optimal lifecycle cost",
+          "type": "number"
+        },
+        "npv_us_dollars": {
+          "description": "Net present value of savings realized by the project",
+          "type": "number"
+        },
+        "year_one_energy_cost_us_dollars": {
+          "description": "Optimal year one utility energy cost",
+          "type": "number"
+        },
+        "year_one_demand_cost_us_dollars": {
+          "description": "Optimal year one utility demand cost",
+          "type": "number"
+        },
+        "year_one_bill_us_dollars": {
+          "description": "Optimal year one utility bill",
+          "type": "number"
+        },
+        "total_energy_cost_us_dollars": {
+          "description": "Total utility energy cost over the lifecycle, after-tax",
+          "type": "number"
+        },
+        "SolarPV": {
+          "$ref": "#/definitions/SolarPV"
+        },
+        "Wind": {
+          "$ref": "#/definitions/Wind"
+        },
+        "Generator": {
+          "$ref": "#/definitions/Generator"
+        },
+        "Storage": {
+          "$ref": "#/definitions/Storage"
+        }
+      }
+    },
+    "SolarPV": {
+      "type": "object",
+      "properties": {
+        "size_kw": {
+          "description": "rated power in kW",
+          "type": "number"
+        },
+        "location": {
+          "description": "Location of PV. Available options are roof, ground or both.",
+          "type": "string",
+          "enum": [
+            "roof",
+            "ground",
+            "both"
+          ]
+        },
+        "tilt": {
+          "description": "PV system tilt",
+          "type": "number"
+        },
+        "azimuth": {
+          "description": "PV azimuth angle",
+          "type": "number"
+        }
+      }
+    },
+    "Wind": {
+      "type": "object",
+      "properties": {
+        "size_kw": {
+          "description": "rated power in kW",
+          "type": "number"
+        },
+        "average_yearly_energy_produced_kwh": {
+          "description": "average yearly energy produced in kWh",
+          "type": "number"
+        },
+        "size_class": {
+          "description": "Turbine size-class. One of [residential, commercial, medium, large]",
+          "type": "string"
+        }
+      }
+    },
+    "Generator": {
+      "type": "object",
+      "properties": {
+        "size_kw": {
+          "description": "rated power in kW",
+          "type": "number"
+        }
+      }
+    },
+    "Storage": {
+      "type": "object",
+      "properties": {
+        "size_kw": {
+          "description": "rated power in kW",
+          "type": "number"
+        },
+        "size_kwh": {
+          "description": "rated capacity in kWh",
+          "type": "number"
+        }
+      }
+    },
+    "RnmResults": {
+      "type": "object",
+      "properties": {
+        "demand_generation_planning": {
+          "description": "Demand generation planning",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DemandGenPlanning"
+          }
+        },
+        "electrical_lines_length": {
+          "$ref": "#/definitions/LineLength"
+        },
+        "distribution_transformers_capacity_kva": {
+          "description": "Distribution transformers capacity in kVA",
+          "type": "number"
+        },
+        "costs": {
+          "description": "Costs",
+          "type": "object",
+          "properties": {
+            "investment": {
+              "$ref": "#/definitions/RnmCost"
+            },
+            "yearly_maintenance": {
+              "$ref": "#/definitions/RnmCost"
+            }
+          }
+        },
+        "reliability_indexes": {
+          "description": "Reliability Indexes",
+          "type": "object",
+          "properties": {
+            "SAIDI": {
+              "description": "System Average Interruption Duration Index",
+              "type": "number"
+            },
+            "SAIFI": {
+              "description": "System Average Interruption Frequency Index",
+              "type": "number"
+            }
+          }
+        }
+      }
+    },
+    "DemandGenPlanning": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Type of demand generation planning",
+          "type": "string",
+          "enum": [
+            "Low Voltage (LV) Consumers",
+            "Medium Voltage (MV) Consumers",
+            "Low Voltage (LV) Distributed generators",
+            "Medium Voltage (MV) Distributed generators"
+          ]
+        },
+        "peak_demand_kw": {
+          "description": "Peak demand in kw for this type",
+          "type": "number"
+        },
+        "number_of_nodes_in_network": {
+          "description": "Number of nodes of this type in the network",
+          "type": "number"
+        }
+      }
+    },
+    "LineLength": {
+      "overhead_mi": {
+        "description": "Length of overhead lines (miles)",
+        "type": "number"
+      },
+      "underground_mi": {
+        "description": "Length of underground lines (miles)",
+        "type": "number"
+      },
+      "type": "object",
+      "properties": {
+        "overhead_mi": {
+          "description": "Length of overhead lines (miles)",
+          "type": "number"
+        },
+        "underground_mi": {
+          "description": "Length of underground lines (miles)",
+          "type": "number"
+        }
+      }
+    },
+    "RnmCost": {
+      "low_voltage_network": {
+        "description": "Low Voltage Network Cost ($)",
+        "type": "number"
+      },
+      "distribution_transformers": {
+        "description": "Distribution Transformers Cost ($)",
+        "type": "number"
+      },
+      "medium_voltage_network": {
+        "description": "Medium Voltage Network Cost ($)",
+        "type": "number"
+      },
+      "primary_substations": {
+        "description": "Primary Substations Cost ($)",
+        "type": "number"
+      },
+      "total": {
+        "description": "Total Cost ($)",
+        "type": "number"
+      },
+      "type": "object",
+      "properties": {
+        "low_voltage_network": {
+          "description": "Low Voltage Network Cost ($)",
+          "type": "number"
+        },
+        "distribution_transformers": {
+          "description": "Distribution Transformers Cost ($)",
+          "type": "number"
+        },
+        "medium_voltage_network": {
+          "description": "Medium Voltage Network Cost ($)",
+          "type": "number"
+        },
+        "primary_substations": {
+          "description": "Primary Substations Cost ($)",
+          "type": "number"
+        },
+        "total": {
+          "description": "TOtal Cost ($)",
+          "type": "number"
+        }
+      }
+    },
+    "qaqc_flags": {
+      "type": "object",
+      "properties": {
+        "eui_reasonableness": {
+          "description": "Whether the EUI is within ASHRAE 90.1-2013 bounds for that building type",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "end_use_by_category": {
+          "description": "Whether building energy use is within ASHRAE 90.1-2013 bounds for that building type",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "mechanical_system_part_load_efficiency": {
+          "description": "Whether 40% & 80% heating and cooling efficiency is within ASHRAE 90.1-2013 bounds for that building type",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "simultaneous_heating_and_cooling": {
+          "description": "Whether heating and cooling are occuring during the same hour when cooling load exists",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "internal_loads": {
+          "description": "Whether lighting, plug, and equipment use is within ASHRAE 90.1-2013 bounds for that building type",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "schedules": {
+          "description": "Whether lighting, ventilation, occupant, plug, and equipment schedules are within ASHRAE 90.1-2013 bounds for that building type",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "envelope_r_value": {
+          "description": "Whether building envelope is within ASHRAE 90.1-2013 bounds for that building type",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "domestic_hot_water": {
+          "description": "Whether DHW energy use is within 2011 ASHRAE handbook bounds for that building type",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "mechanical_system_efficiency": {
+          "description": "Whether heating and cooling efficiency is within ASHRAE 90.1-2013 bounds for that building type",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "supply_and_zone_air_temperature": {
+          "description": "Whether fan effectiveness is within ASHRAE 90.1-2013 bounds for that building type",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "total_qaqc_flags": {
+          "description": "How many QAQC flags have been raised for this feature or scenario",
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      }
+    },
+    "FeatureReport": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Id refers to the id of a building/feature",
+          "type": "string"
+        },
+        "name": {
+          "description": "name refers to the name of the feature (eg. Building 1, tranformer 5)",
+          "type": "string"
+        },
+        "directory_name": {
+          "type": "string"
+        },
+        "feature_type": {
+          "type": "string",
+          "enum": [
+            "Building",
+            "District System",
+            "Transformer"
+          ]
+        },
+        "timesteps_per_hour": {
+          "$ref": "#/definitions/TimestepsPerHour"
+        },
+        "simulation_status": {
+          "type": "string",
+          "enum": [
+            "Not Started",
+            "Started",
+            "Complete",
+            "Failed"
+          ]
+        },
+        "timeseries_csv": {
+          "$ref": "#/definitions/TimeseriesCSV"
+        },
+        "location": {
+          "$ref": "#/definitions/Location"
+        },
+        "program": {
+          "$ref": "#/definitions/Program"
+        },
+        "design_parameters": {
+          "$ref": "#/definitions/DesignParameters"
+        },
+        "construction_costs": {
+          "$ref": "#/definitions/ConstructionCosts"
+        },
+        "reporting_periods": {
+          "$ref": "#/definitions/ReportingPeriods"
+        },
+        "distributed_generation": {
+          "$ref": "#/definitions/DistributedGeneration"
+        },
+        "power_distribution": {
+          "$ref": "#/definitions/PowerDistribution"
+        },
+        "thermal_storage": {
+          "$ref": "#/definitions/ThermalStorage"
+        },
+        "qaqc_flags": {
+          "$ref": "#/definitions/qaqc_flags"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "directory_name",
+        "feature_type",
+        "timesteps_per_hour",
+        "simulation_status"
+      ],
+      "additionalProperties": false
+    },
+    "ReportingPeriods": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ReportingPeriod"
+      }
+    },
+    "ReportingPeriod": {
+      "description": "Non-overlapping reporting periods",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Id refers to the id of the reporting period. Ids of reporting periods are matched across simulations, so the same period of time gets the same id for all simulations.",
+          "type": "number"
+        },
+        "name": {
+          "description": "name refers to the name of the reporting period(eg. Annual, January)",
+          "type": "string"
+        },
+        "multiplier": {
+          "description": "Multiplier used if this reporting period is representative of mulitple periods.  For example one week simulation that represents entire month.",
+          "type": "number",
+          "default": 1
+        },
+        "start_date": {
+          "$ref": "#/definitions/Date"
+        },
+        "end_date": {
+          "$ref": "#/definitions/Date"
+        },
+        "total_site_energy_kwh": {
+          "description": "Total energy used on site, does not include generation (kWh)",
+          "type": "number"
+        },
+        "total_source_energy_kwh": {
+          "description": "Total source energy used, does not include generation (kWh)",
+          "type": "number"
+        },
+        "site_EUI_kwh_per_m2": {
+          "type": "number"
+        },
+        "site_EUI_kBtu_per_ft2": {
+          "type": "number"
+        },
+        "source_EUI_kwh_per_m2": {
+          "type": "number"
+        },
+        "source_EUI_kBtu_per_ft2": {
+          "type": "number"
+        },
+        "net_site_energy_kwh": {
+          "description": "Net site energy (kWh)",
+          "type": "number"
+        },
+        "net_source_energy_kwh": {
+          "description": "Net source energy (kWh)",
+          "type": "number"
+        },
+        "total_utility_cost_dollar": {
+          "description": "Total utility cost ($)",
+          "type": "number"
+        },
+        "net_utility_cost_dollar": {
+          "description": "Net utility cost for reporting period includes generation ($)",
+          "type": "number"
+        },
+        "utility_costs_dollar": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UtilityCost"
+          }
+        },
+        "electricity_kwh": {
+          "description": "Sum of all electricity used, does not include electricity produced (kWh)",
+          "type": "number"
+        },
+        "natural_gas_kwh": {
+          "description": "Sum of all natural gas end uses consumption (kWh)",
+          "type": "number"
+        },
+        "propane_kwh": {
+          "description": "Sum of all propane end uses consumption (kWh)",
+          "type": "number"
+        },
+        "fuel_oil_kwh": {
+          "description": "Sum of all fuel oil #2 end uses consumption (kWh)",
+          "type": "number"
+        },
+        "other_fuels_kwh": {
+          "description": "Sum of all other (fuel oil #1, diesel, gasoline, coal, steam) fuel end uses consumption (kWh)",
+          "type": "number"
+        },
+        "district_cooling_kwh": {
+          "description": "Sum of all distric cooling end uses consumption (kWh)",
+          "type": "number"
+        },
+        "district_heating_kwh": {
+          "description": "Sum of all distric heating end uses consumption (kWh)",
+          "type": "number"
+        },
+        "water_qbft": {
+          "description": "Sum of all water end uses consumption (ft^3)",
+          "type": "number"
+        },
+        "electricity_produced_kwh": {
+          "description": "Sum of all electricity produced (kWh)",
+          "type": "number"
+        },
+        "end_uses": {
+          "$ref": "#/definitions/EndUses"
+        },
+        "energy_production_kwh": {
+          "description": "Energy produced for reporting period.  Water reported in m^3, all others in kWh.",
+          "type": "object",
+          "properties": {
+            "electricity_produced": {
+              "type": "object",
+              "properties": {
+                "photovoltaic": {
+                  "type": "number"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "comfort_result": {
+          "$ref": "#/definitions/ComfortResult"
+        },
+        "emissions": {
+          "type": "object",
+          "properties": {
+            "future_annual_electricity_emissions_mt": {
+              "description": "Future emissions in metric ton (mt) calculated based on an annual emission factor value for the selected future year",
+              "type": "number"
+            },
+            "future_hourly_electricity_emissions_mt": {
+              "description": "Future emissions in metric ton (mt) calculated based on hourly emission factor values for the selected future year",
+              "type": "number"
+            },
+            "historical_annual_electricity_emissions_mt": {
+              "description": "Historical emissions in metric ton (mt) calculated based on an annual emission factor value for the selected historical year",
+              "type": "number"
+            },
+            "historical_hourly_electricity_emissions_mt": {
+              "description": "Historical emissions in metric ton (mt) calculated based on hourly emission factor values for the selected historical year",
+              "type": "number"
+            },
+            "future_annual_electricity_emissions_intensity_kg_per_ft2": {
+              "description": "Future emissions intensity in kg/ft2 calculated based on an annual emission factor value for the selected future year",
+              "type": "number"
+            },
+            "future_hourly_electricity_emissions_intensity_kg_per_ft2": {
+              "description": "Future emissions intensity in kg/ft2 calculated based on hourly emission factor values for the selected future year",
+              "type": "number"
+            },
+            "historical_annual_electricity_emissions_intensity_kg_per_ft2": {
+              "description": "Historical emissions intensity in kg/ft2 calculated based on an annual emission factor value for the selected historical year",
+              "type": "number"
+            },
+            "historical_hourly_electricity_emissions_intensity_kg_per_ft2": {
+              "description": "Historical emissions intensity in kg/ft2 calculated based on hourly emission factor values for the selected historical year",
+              "type": "number"
+            },
+            "natural_gas_emissions_mt": {
+              "description": "Natural Gas emissions in mt calculated based on EPA eGRID data and calculated using 20-year GWP horizon based on ASHRAE 189.1",
+              "type": "number"
+            },
+            "natural_gas_emissions_intensity_kg_per_ft2": {
+              "description": "Natural Gas emissions intensity in kg/ft2 calculated based on EPA eGRID data and calculated using 20-year GWP horizon based on ASHRAE 189.1",
+              "type": "number"
+            },
+            "propane_emissions_mt": {
+              "description": "Propane emissions in mt calculated based on EPA eGRID data and calculated using 20-year GWP horizon based on ASHRAE 189.1",
+              "type": "number"
+            },
+            "propane_emissions_intensity_kg_per_ft2": {
+              "description": "Propane emissions intensity in kg/ft2 calculated based on EPA eGRID data and calculated using 20-year GWP horizon based on ASHRAE 189.1",
+              "type": "number"
+            },
+            "fueloil_no2_emissions_mt": {
+              "description": "FuelOilNo2 emissions in mt calculated based on EPA eGRID data and calculated using 20-year GWP horizon based on ASHRAE 189.1",
+              "type": "number"
+            },
+            "fueloil_no2_emissions_intensity_kg_per_ft2": {
+              "description": "FuelOilNo2 emissions intensity in kg/ft2 calculated based on EPA eGRID data and calculated using 20-year GWP horizon based on ASHRAE 189.1",
+              "type": "number"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "Date": {
+      "type": "object",
+      "properties": {
+        "month": {
+          "type": "integer"
+        },
+        "day_of_month": {
+          "type": "integer"
+        },
+        "year": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false
+    },
+    "EndUses": {
+      "description": "End uses for reporting period.  Does not include energy produced. Water reported in m^3, all others in kWh.",
+      "type": "object",
+      "properties": {
+        "electricity_kwh": {
+          "$ref": "#/definitions/EndUse"
+        },
+        "natural_gas_kwh": {
+          "$ref": "#/definitions/EndUse"
+        },
+        "propane_kwh": {
+          "$ref": "#/definitions/EndUse"
+        },
+        "fuel_oil_kwh": {
+          "$ref": "#/definitions/EndUse"
+        },
+        "other_fuels_kwh": {
+          "$ref": "#/definitions/EndUse"
+        },
+        "district_cooling_kwh": {
+          "$ref": "#/definitions/EndUse"
+        },
+        "district_heating_kwh": {
+          "$ref": "#/definitions/EndUse"
+        },
+        "water_qbft": {
+          "$ref": "#/definitions/EndUse"
+        }
+      },
+      "additionalProperties": false
+    },
+    "EndUse": {
+      "type": "object",
+      "properties": {
+        "heating": {
+          "type": "number"
+        },
+        "cooling": {
+          "type": "number"
+        },
+        "interior_lighting": {
+          "type": "number"
+        },
+        "exterior_lighting": {
+          "type": "number"
+        },
+        "interior_equipment": {
+          "type": "number"
+        },
+        "exterior_equipment": {
+          "type": "number"
+        },
+        "electric_vehicles": {
+          "type": "number"
+        },
+        "fans": {
+          "type": "number"
+        },
+        "pumps": {
+          "type": "number"
+        },
+        "heat_rejection": {
+          "type": "number"
+        },
+        "humidification": {
+          "type": "number"
+        },
+        "heat_recovery": {
+          "type": "number"
+        },
+        "water_systems": {
+          "type": "number"
+        },
+        "refrigeration": {
+          "type": "number"
+        },
+        "generators": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ComfortResult": {
+      "type": "object",
+      "properties": {
+        "time_setpoint_not_met_during_occupied_cooling": {
+          "description": "(hrs)",
+          "type": "number"
+        },
+        "time_setpoint_not_met_during_occupied_heating": {
+          "description": "(hrs)",
+          "type": "number"
+        },
+        "time_setpoint_not_met_during_occupied_hours": {
+          "description": "(hrs)",
+          "type": "number"
+        },
+        "hours_out_of_comfort_bounds_PMV": {
+          "type": "number"
+        },
+        "hours_out_of_comfort_bounds_PPD": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ConstructionCosts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ConstructionCost"
+      }
+    },
+    "ConstructionCost": {
+      "description": "Program related information, does not change in time",
+      "type": "object",
+      "properties": {
+        "category": {
+          "type": "string",
+          "enum": [
+            "Construction",
+            "Building",
+            "Space",
+            "ThermalZone",
+            "AirLoop",
+            "PlantLoop",
+            "ZoneHVAC",
+            "Lights",
+            "Luminaire",
+            "Equipment",
+            "HVACComponent",
+            "ZoneHVACComponent"
+          ]
+        },
+        "item_name": {
+          "description": "Name of the item being costed, e.g. the name of the exterior wall construction",
+          "type": "string"
+        },
+        "unit_cost": {
+          "description": "Cost per unit of item, e.g. cost per area of construction.  This can be adjusted in post processing.",
+          "type": "number"
+        },
+        "cost_units": {
+          "description": "Unit of cost for this item",
+          "type": "string",
+          "enum": [
+            "CostPerEach",
+            "CostPerFt2",
+            "CostPerKW",
+            "CostPerCFM"
+          ]
+        },
+        "item_quantity": {
+          "description": "Amount of the item in units corresponding to cost_units",
+          "type": "number"
+        },
+        "total_cost": {
+          "description": "Total cost is unit_cost multiplied by item_quantity. Can be updated if unit_cost is changed.",
+          "type": "number"
+        }
+      },
+      "additionalProperties": false
+    },
+    "UtilityCost": {
+      "type": "object",
+      "properties": {
+        "fuel_type": {
+          "type": "string",
+          "enum": [
+            "Electricity",
+            "Natural Gas",
+            "Propane",
+            "Fuel Oil",
+            "District Cooling",
+            "District Heating",
+            "Other Fuels",
+            "Water"
+          ]
+        },
+        "total_cost": {
+          "description": "($)",
+          "type": "number"
+        },
+        "usage_cost": {
+          "description": "($)",
+          "type": "number"
+        },
+        "demand_cost": {
+          "description": "($)",
+          "type": "number"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Location": {
+      "type": "object",
+      "properties": {
+        "latitude_deg": {
+          "description": "latitude for the centroid of the feature (deg)",
+          "type": "number"
+        },
+        "longitude_deg": {
+          "description": "longitude for the centroid of the feature (deg)",
+          "type": "number"
+        },
+        "surface_elevation_ft": {
+          "description": "The surface elevation (above NAVD88 datum) (ft).",
+          "type": "number"
+        },
+        "weather_filename": {
+          "description": "Name of EPW weather file.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "TimestepsPerHour": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 60
+    },
+    "Program": {
+      "type": "object",
+      "properties": {
+        "site_area_sqft": {
+          "description": "Area of the entire site or lot (ft^2)",
+          "type": "number"
+        },
+        "floor_area_sqft": {
+          "description": "Building gross floor area (ft^2)",
+          "type": "number"
+        },
+        "conditioned_area_sqft": {
+          "description": "Building conditioned floor area (ft^2)",
+          "type": "number"
+        },
+        "unconditioned_area_sqft": {
+          "description": "Building unconditioned floor area (ft^2)",
+          "type": "number"
+        },
+        "footprint_area_sqft": {
+          "description": "Building floorprint area (ft^2)",
+          "type": "number"
+        },
+        "maximum_roof_height_ft": {
+          "description": "Maximum height of the roof relative to surface elevation (ft)",
+          "type": "number"
+        },
+        "maximum_number_of_stories": {
+          "description": "The maximum number of building stories, sum of number of above and below ground stories.",
+          "type": "number"
+        },
+        "maximum_number_of_stories_above_ground": {
+          "description": "The maximum number of building stories above ground",
+          "type": "number"
+        },
+        "parking_area_sqft": {
+          "description": "Parking gross area (ft^2)",
+          "type": "number"
+        },
+        "number_of_parking_spaces": {
+          "description": "Number of parking spaces",
+          "type": "number"
+        },
+        "number_of_parking_spaces_charging": {
+          "description": "Number of parking spaces with electric vehicle charging",
+          "type": "number"
+        },
+        "parking_footprint_area_sqft": {
+          "description": "Parking floorprint area (ft^2)",
+          "type": "number"
+        },
+        "maximum_parking_height_ft": {
+          "description": "Maximum height of the parking structure relative to surface elevation (ft)",
+          "type": "number"
+        },
+        "maximum_number_of_parking_stories": {
+          "description": "The maximum number of parking stories, sum of number of above and below ground stories.",
+          "type": "number"
+        },
+        "maximum_number_of_parking_stories_above_ground": {
+          "description": "The maximum number of parking stories above ground",
+          "type": "number"
+        },
+        "number_of_residential_units": {
+          "description": "Total number of residential units.",
+          "type": "integer"
+        },
+        "building_types": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BuildingType"
+          }
+        },
+        "window_area_sqft": {
+          "description": "Exterior windows gross area (ft^2)",
+          "type": "object",
+          "properties": {
+            "north_window_area_sqft": {
+              "type": "number"
+            },
+            "south_window_area_sqft": {
+              "type": "number"
+            },
+            "east_window_area_sqft": {
+              "type": "number"
+            },
+            "west_window_area_sqft": {
+              "type": "number"
+            },
+            "total_window_area_sqft": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "total_window_area_sqft"
+          ],
+          "additionalProperties": false
+        },
+        "wall_area_sqft": {
+          "description": "exterior walls gross area (ft^2)",
+          "type": "object",
+          "properties": {
+            "north_wall_area_sqft": {
+              "type": "number"
+            },
+            "south_wall_area_sqft": {
+              "type": "number"
+            },
+            "east_wall_area_sqft": {
+              "type": "number"
+            },
+            "west_wall_area_sqft": {
+              "type": "number"
+            },
+            "total_wall_area_sqft": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "north_wall_area_sqft",
+            "south_wall_area_sqft",
+            "east_wall_area_sqft",
+            "west_wall_area_sqft",
+            "total_wall_area_sqft"
+          ],
+          "additionalProperties": false
+        },
+        "roof_area_sqft": {
+          "type": "object",
+          "properties": {
+            "equipment_roof_area_sqft": {
+              "type": "number"
+            },
+            "photovoltaic_roof_area_sqft": {
+              "type": "number"
+            },
+            "available_roof_area_sqft": {
+              "description": "gross roof area (ft^2)",
+              "type": "number"
+            },
+            "total_roof_area_sqft": {
+              "description": "Exterior roofs gross area (ft^2)",
+              "type": "number"
+            }
+          },
+          "required": [
+            "total_roof_area_sqft"
+          ],
+          "additionalProperties": false
+        },
+        "orientation_deg": {
+          "description": "Rotation of longest axis from East-West,about up axis (deg)",
+          "type": "number"
+        },
+        "aspect_ratio": {
+          "description": "Ratio of longest to shortest axis",
+          "type": "number"
+        },
+        "total_construction_cost_dollar": {
+          "description": "total construction cost calculated from the defined cost per floor area ($)",
+          "type": "number"
+        }
+      },
+      "required": [
+        "floor_area_sqft",
+        "conditioned_area_sqft",
+        "unconditioned_area_sqft",
+        "footprint_area_sqft",
+        "maximum_roof_height_ft",
+        "number_of_residential_units",
+        "building_types",
+        "window_area_sqft",
+        "wall_area_sqft",
+        "roof_area_sqft"
+      ],
+      "additionalProperties": false
+    },
+    "BuildingType": {
+      "type": "object",
+      "properties": {
+        "building_type": {
+          "description": "Primary building space type",
+          "type": "string",
+          "enum": [
+            "Single-Family",
+            "Multifamily (2 to 4 units)",
+            "Multifamily (5 or more units)",
+            "Mobile Home",
+            "Vacant",
+            "Office",
+            "Laboratory",
+            "Nonrefrigerated warehouse",
+            "Food sales",
+            "Public order and safety",
+            "Outpatient health care",
+            "Refrigerated warehouse",
+            "Religious worship",
+            "Public assembly",
+            "Education",
+            "Food service",
+            "Inpatient health care",
+            "Nursing",
+            "Lodging",
+            "Strip shopping mall",
+            "Enclosed mall",
+            "Retail other than mall",
+            "Service"
+          ]
+        },
+        "maximum_occupancy": {
+          "description": "Maximum number of occupants ",
+          "type": "number"
+        },
+        "floor_area": {
+          "description": "Building gross floor area of this type (ft^2)",
+          "type": "number"
+        }
+      },
+      "required": [
+        "building_type",
+        "maximum_occupancy",
+        "floor_area"
+      ],
+      "additionalProperties": false
+    },
+    "DesignParameters": {
+      "type": "object",
+      "properties": {
+        "district_cooling_chilled_water_rate": {
+          "type": "number"
+        },
+        "district_cooling_mass_flow_rate": {
+          "type": "number"
+        },
+        "district_cooling_inlet_temperature": {
+          "type": "number"
+        },
+        "district_cooling_outlet_temperature": {
+          "type": "number"
+        },
+        "district_heating_hot_water_rate": {
+          "type": "number"
+        },
+        "district_heating_mass_flow_rate": {
+          "type": "number"
+        },
+        "district_heating_inlet_temperature": {
+          "type": "number"
+        },
+        "district_heating_outlet_temperature": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false
+    },
+    "TimeseriesCSV": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "first_report_datetime": {
+          "type": "string"
+        },
+        "column_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "path",
+        "first_report_datetime",
+        "column_names"
+      ],
+      "additionalProperties": false
+    },
+    "PowerDistribution": {
+      "type": "object",
+      "properties": {
+        "over_voltage_hours": {
+          "type": "number"
+        },
+        "under_voltage_hours": {
+          "type": "number"
+        }
+      }
+    },
+    "ThermalStorage": {
+      "type": "object",
+      "properties": {
+        "its_size": {
+          "description": "Total central plant TES capacity in kWh",
+          "type": "number"
+        },
+        "ptes_size": {
+          "description": "Total distributed/packaged TES capacity in kWh",
+          "type": "number"
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
### Pull Request Description
The schema had errors that were not found until I tried regenerating the documentation. This fixes the errors. It's hard to see the fixes because the indenting was changed at the same time. Sorry about that. You can confirm that the old schema fails to validate and the new one does validate by pasting the entire schema into the lefthand side of https://www.jsonschemavalidator.net/ and looking for error messages below where you pasted.

### Checklist (Delete lines that don't apply)

- [x] All ci tests pass (green)
- [x] This branch is up-to-date with develop
