### PR TITLE
trigger CI on PR review_request

### DIFF
--- a/.github/workflows/nightly_ci_build.yml
+++ b/.github/workflows/nightly_ci_build.yml
@@ -6,6 +6,8 @@ on:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
     # 5 am UTC (11pm MDT the day before) every weekday night in MDT
     - cron: '22 5 * * 2-6'
+  pull_request:
+    types: [review_requested]
 
 env:
   # This env var should enforce develop branch of all dependencies


### PR DESCRIPTION
### Pull Request Description

CI appeared to be only running on the default branch on the schedule. This also adds a CI run on branches when review is requested on a PR. 

### Checklist

- [x] All ci tests pass (green)
- [x] This branch is up-to-date with develop
