### PR TITLE
Upgrade to OpenStudio 3.8 & Ruby 3.2

### DIFF
--- a/.github/workflows/nightly_ci_build.yml
+++ b/.github/workflows/nightly_ci_build.yml
@@ -26,8 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: set git config options
         shell: bash
-        run: |
-          git config --global --add safe.directory '*'
+        run: git config --global --add safe.directory '*'
       - name: Update gems
         run: |
           ruby --version
@@ -35,7 +34,9 @@ jobs:
       - name: List OpenStudio measures
         run: bundle exec rake openstudio:list_measures
       - name: Update OpenStudio measures
-        run: bundle exec rake openstudio:update_measures
+        run: |
+          bundle install
+          bundle exec rake openstudio:update_measures
       - name: Test OpenStudio measures
         run: bundle exec rake openstudio:test_with_openstudio
       - name: Run Rspec

--- a/.github/workflows/nightly_ci_build.yml
+++ b/.github/workflows/nightly_ci_build.yml
@@ -21,7 +21,7 @@ jobs:
   weeknight-tests:
     runs-on: ubuntu-latest
     container:
-      image: docker://nrel/openstudio:3.7.0
+      image: docker://nrel/openstudio:3.8.0
     steps:
       - uses: actions/checkout@v4
       - name: set git config options

--- a/.github/workflows/nightly_ci_build.yml
+++ b/.github/workflows/nightly_ci_build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Update gems
         run: |
           ruby --version
-          bundle update
+          bundle install
       - name: List OpenStudio measures
         run: bundle exec rake openstudio:list_measures
       - name: Update OpenStudio measures

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /lib/measures/*/tests/output
 out.txt
 .rubocop*s3*
+.coverage
 
 # rspec failure tracking
 .rspec_status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # URBANopt Reporting Gem
 
+## Version 0.11.0
+* Upgrade to OpenStudio 3.8 & Ruby 3.2 by @vtnate in https://github.com/urbanopt/urbanopt-reporting-gem/pull/154
+
+**Full Changelog**: https://github.com/urbanopt/urbanopt-reporting-gem/compare/v0.10.1...v0.11.0
+
 ## Version 0.10.1
 * Other Fuel emission factors update by @rawadelkontar in https://github.com/urbanopt/urbanopt-reporting-gem/pull/153
 

--- a/Gemfile
+++ b/Gemfile
@@ -21,5 +21,5 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # if allow_local && File.exist?('../openstudio-extension-gem')
 #   gem 'openstudio-extension', path: '../openstudio-extension-gem'
 # elsif allow_local
-#   gem 'openstudio-extension', github: 'NREL/openstudio-extension-gem', branch: 'develop'
+  gem 'openstudio-extension', github: 'NREL/openstudio-extension-gem', branch: 'dont_raise_when_mistmatch'
 # end

--- a/Gemfile
+++ b/Gemfile
@@ -12,11 +12,11 @@ gemspec
 allow_local = ENV['FAVOR_LOCAL_GEMS']
 
 # pin this dependency to avoid unicode_normalize error
-gem 'addressable', '2.8.1'
+# gem 'addressable', '2.8.1'
 # pin this dependency to avoid using racc dependency (which has native extensions)
-gem 'parser', '3.2.2.2'
+# gem 'parser', '3.2.2.2'
 # pin this dependency because 2.9.2 breaks OS tests (openstudio:test_with_openstudio)
-gem 'regexp_parser', '2.9.0'
+# gem 'regexp_parser', '2.9.0'
 
 # if allow_local && File.exist?('../openstudio-extension-gem')
 #   gem 'openstudio-extension', path: '../openstudio-extension-gem'

--- a/Gemfile
+++ b/Gemfile
@@ -11,16 +11,16 @@ gemspec
 # checkout the latest version (develop) from github.
 allow_local = ENV['FAVOR_LOCAL_GEMS']
 
-# pin this dependency to avoid unicode_normalize error
-# gem 'addressable', '2.8.1'
+# pin this dependency to avoid unicode_normalize error (openstudio:test_with_openstudio)
+gem 'addressable', '2.8.1'
 # pin this dependency to avoid using racc dependency (which has native extensions)
 # gem 'parser', '3.2.2.2'
 # pin this dependency because 2.9.2 breaks OS tests (openstudio:test_with_openstudio)
-# gem 'regexp_parser', '2.9.0'
+gem 'regexp_parser', '2.9.0'
 
 # if allow_local && File.exist?('../openstudio-extension-gem')
 #   gem 'openstudio-extension', path: '../openstudio-extension-gem'
 # elsif allow_local
-  # gem 'openstudio-extension', github: 'NREL/openstudio-extension-gem', branch: 'develop'
+# gem 'openstudio-extension', github: 'NREL/openstudio-extension-gem', branch: 'develop'
 # gem 'openstudio-extension', '~> 0.8.1'
 # end

--- a/Gemfile
+++ b/Gemfile
@@ -21,5 +21,6 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # if allow_local && File.exist?('../openstudio-extension-gem')
 #   gem 'openstudio-extension', path: '../openstudio-extension-gem'
 # elsif allow_local
-  gem 'openstudio-extension', github: 'NREL/openstudio-extension-gem', branch: 'dont_raise_when_mistmatch'
+  # gem 'openstudio-extension', github: 'NREL/openstudio-extension-gem', branch: 'develop'
+# gem 'openstudio-extension', '~> 0.8.1'
 # end

--- a/lib/measures/default_feature_reports/measure.xml
+++ b/lib/measures/default_feature_reports/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>default_feature_reports</name>
   <uid>9ee3135a-8070-4408-bfa1-b75fecf9dd4f</uid>
-  <version_id>1f0dd70a-ddad-4bb8-a54b-0aeb696e80d0</version_id>
-  <version_modified>2024-06-20T19:28:12Z</version_modified>
+  <version_id>43be79bc-ba24-44e0-923f-3f618951a054</version_id>
+  <version_modified>2024-07-16T17:52:08Z</version_modified>
   <xml_checksum>FB304155</xml_checksum>
   <class_name>DefaultFeatureReports</class_name>
   <display_name>DefaultFeatureReports</display_name>
@@ -128,7 +128,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>005CDD6D</checksum>
+      <checksum>2B9D1AAE</checksum>
     </file>
     <file>
       <filename>USA_CO_Golden-NREL.724666_TMY3.epw</filename>

--- a/lib/measures/export_time_series_modelica/measure.xml
+++ b/lib/measures/export_time_series_modelica/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>export_time_series_loads_csv</name>
   <uid>9fcf6116-c2eb-43d6-93f0-e1bdd822f768</uid>
-  <version_id>0b134568-d3a8-4ede-bf22-2010a173ea97</version_id>
-  <version_modified>2024-01-08T22:54:07Z</version_modified>
+  <version_id>8bd4bc8e-f597-47f9-82b9-044a06977bb1</version_id>
+  <version_modified>2024-07-16T17:52:07Z</version_modified>
   <xml_checksum>9BF1E6AC</xml_checksum>
   <class_name>ExportTimeSeriesLoadsCSV</class_name>
   <display_name>ExportTimeSeriesLoadsCSV</display_name>
@@ -111,7 +111,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>EC8615DF</checksum>
+      <checksum>EB4FBA91</checksum>
     </file>
     <file>
       <filename>os_lib_helper_methods.rb</filename>

--- a/lib/urbanopt/reporting/version.rb
+++ b/lib/urbanopt/reporting/version.rb
@@ -5,6 +5,6 @@
 
 module URBANopt
   module Reporting
-    VERSION = '0.10.1'.freeze
+    VERSION = '0.11.0'.freeze
   end
 end

--- a/urbanopt-reporting-gem.gemspec
+++ b/urbanopt-reporting-gem.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '~> 3.2'
+  # We support exactly Ruby v3.2.2 because os-extension requires bundler==2.4.10 and that requires Ruby 3.2.2: https://stdgems.org/bundler/
+  # It would be nice to be able to use newer patches of Ruby 3.2, which would require os-extension to relax its dependency on bundler.
+  spec.required_ruby_version = '3.2.2'
 
-  spec.add_development_dependency 'bundler', '~> 2.4.10'
-  spec.add_development_dependency 'rake', '~> 13.2'
   spec.add_development_dependency 'rspec', '~> 3.13'
   spec.add_development_dependency 'simplecov', '0.22.0'
   spec.add_development_dependency 'simplecov-lcov', '0.8.0'

--- a/urbanopt-reporting-gem.gemspec
+++ b/urbanopt-reporting-gem.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'json_pure', '~> 2.3'
   spec.add_runtime_dependency 'json-schema', '~> 2.7'
-  spec.add_dependency 'openstudio-extension', '~> 0.8.0'
+  # spec.add_dependency 'openstudio-extension', '~> 0.8.0'
 end

--- a/urbanopt-reporting-gem.gemspec
+++ b/urbanopt-reporting-gem.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'json_pure', '~> 2.7'
   spec.add_runtime_dependency 'json-schema', '~> 4.3.1'
-  # spec.add_dependency 'openstudio-extension', '~> 0.8.0'
+  spec.add_dependency 'openstudio-extension', '~> 0.8.1'
 end

--- a/urbanopt-reporting-gem.gemspec
+++ b/urbanopt-reporting-gem.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '0.22.0'
   spec.add_development_dependency 'simplecov-lcov', '0.8.0'
 
-  spec.add_runtime_dependency 'json_pure', '~> 2.3'
-  spec.add_runtime_dependency 'json-schema', '~> 2.7'
+  spec.add_runtime_dependency 'json_pure', '~> 2.7'
+  spec.add_runtime_dependency 'json-schema', '~> 4.3.1'
   # spec.add_dependency 'openstudio-extension', '~> 0.8.0'
 end

--- a/urbanopt-reporting-gem.gemspec
+++ b/urbanopt-reporting-gem.gemspec
@@ -21,15 +21,15 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '~> 2.7.0'
+  spec.required_ruby_version = '~> 3.2'
 
-  spec.add_development_dependency 'bundler', '~> 2.1'
-  spec.add_development_dependency 'rake', '~> 13.1'
-  spec.add_development_dependency 'rspec', '~> 3.12'
-  spec.add_development_dependency 'simplecov', '~> 0.18.2'
-  spec.add_development_dependency 'simplecov-lcov', '~> 0.8.0'
+  spec.add_development_dependency 'bundler', '~> 2.4.10'
+  spec.add_development_dependency 'rake', '~> 13.2'
+  spec.add_development_dependency 'rspec', '~> 3.13'
+  spec.add_development_dependency 'simplecov', '0.22.0'
+  spec.add_development_dependency 'simplecov-lcov', '0.8.0'
 
   spec.add_runtime_dependency 'json_pure', '~> 2.3'
   spec.add_runtime_dependency 'json-schema', '~> 2.7'
-  spec.add_dependency 'openstudio-extension', '~> 0.7.1'
+  spec.add_dependency 'openstudio-extension', '~> 0.8.0'
 end


### PR DESCRIPTION
### Resolves #[issue number here]

### Pull Request Description

The current version of OpenStudio, [v3.8](https://github.com/NREL/OpenStudio/releases) includes a major breaking change to move from Ruby 2.7.2 to Ruby 3.2.2.

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] Documentation has been modified appropriately
- [ ] All ci tests pass (green)
- [ ] An [ISSUE](https://github.com/urbanopt/urbanopt-reporting-gem/issues) has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run.
- [x] This branch is up-to-date with develop
